### PR TITLE
DataTransform duplicate key bug

### DIFF
--- a/biothings/hub/datatransform/datatransform.py
+++ b/biothings/hub/datatransform/datatransform.py
@@ -39,6 +39,8 @@ class IDStruct(object):
         """add a (original_id, current_id) pair to the list"""
         if not left or not right:
             return  # identifiers cannot be None
+        if self.lookup(left, right):
+            return  # tuple already in the list
         # ensure it's hashable
         if not type(left) in [list,tuple]:
             left = [left]
@@ -48,8 +50,6 @@ class IDStruct(object):
             left = tuple(left)
         if type(right) == list:
             right = tuple(right)
-        if self.lookup(left, right):
-            return  # tuple already in the list
         for v in left:
             if v not in self.forward.keys():
                 self.forward[v] = right

--- a/biothings/hub/datatransform/datatransform_mdb.py
+++ b/biothings/hub/datatransform/datatransform_mdb.py
@@ -133,7 +133,6 @@ class DataTransformMDB(DataTransform):
         self.paths = {}
         for output_type in self.output_types:
             for input_type in self.input_types:
-                self.logger.info("Compute Path From '{}' to '{}'".format(input_type[0], output_type))
                 paths = [p for p in all_simple_paths(self.G, input_type[0], output_type)]
                 if not paths:
                     try:
@@ -150,7 +149,7 @@ class DataTransformMDB(DataTransform):
                 # Sort by path length - try the shortest paths first
                 paths = sorted(paths, key=self._compute_path_weight)
                 self.paths[(input_type[0], output_type)] = paths
-        self.logger.debug("All Travel Paths:  {}".format(self.paths))
+        self.logger.debug("All Pre-Computed DataTransform Paths:  {}".format(self.paths))
 
     def key_lookup_batch(self, batchiter):
         """
@@ -181,7 +180,7 @@ class DataTransformMDB(DataTransform):
                         (hit_lst, miss_lst) = self._copy(input_type, miss_lst)
                 else:    
                     (hit_lst, miss_lst) = self.travel(input_type, output_type, miss_lst)
-                
+
                 for doc in hit_lst:
                     yield doc
 
@@ -273,7 +272,7 @@ class DataTransformMDB(DataTransform):
                 path_strct = self._edge_lookup(edge, path_strct)
                 num_output_ids = len(path_strct)
                 if num_input_ids:
-                    self.logger.debug("Edge {} - {}, {} searched returned {}".format(v1, v2, num_input_ids, num_output_ids))
+                    # self.logger.debug("Edge {} - {}, {} searched returned {}".format(v1, v2, num_input_ids, num_output_ids))
                     self.histogram.update_edge(v1, v2, num_output_ids)
 
             if len(path_strct):

--- a/biothings/tests/test_datatransform.py
+++ b/biothings/tests/test_datatransform.py
@@ -116,6 +116,10 @@ class TestDataTransform(unittest.TestCase):
         res = next(res_lst)
         self.assertEqual(res['_id'], 'd:1234')
 
+        # Verify that the generator is out of documents
+        with self.assertRaises(StopIteration):
+            next(res_lst)
+
     def test_one2many(self):
         """
         test for one to many key lookup - artificial document.


### PR DESCRIPTION
If documents had identical keys, strange things were happening.  In effect, the number of output documents was the number of input documents (with identical keys) squared.  The fix in this patch asserts that duplicate keys are not stored internally.  Further, logging improvements were made.

All tests in test_datatransform.py now pass.