### PR TITLE
DataTransform API Improvements

### DIFF
--- a/biothings/hub/datatransform/datatransform_api.py
+++ b/biothings/hub/datatransform/datatransform_api.py
@@ -363,7 +363,8 @@ class BiothingsAPIEdge(DataTransformEdge):
                 val = nested_lookup(q, field)
                 if val:
                     for (orig_id, curr_id) in id_strct:
-                        if query == curr_id:
+                        # query is always a string, so this check requires conversion
+                        if query == str(curr_id):
                             qm_struct.add(orig_id, val)
         return qm_struct
 

--- a/biothings/hub/datatransform/datatransform_api.py
+++ b/biothings/hub/datatransform/datatransform_api.py
@@ -153,7 +153,7 @@ class DataTransformAPI(DataTransform):
         :param qr: querymany results
         :return:
         """
-        self.logger.debug("QueryMany Structure:  {}".format(qr))
+        # self.logger.debug("QueryMany Structure:  {}".format(qr))
         qm_struct = {}
         for q in qr['out']:
             query = q['query']
@@ -164,9 +164,9 @@ class DataTransformAPI(DataTransform):
                 else:
                     self.one_to_many_cnt += 1
                     qm_struct[query] = qm_struct[query] + [val]
-        self.logger.debug("parse_querymany num qm_struct keys: {}".format(len(qm_struct.keys())))
-        self.logger.info("parse_querymany running one_to_many_cnt: {}".format(self.one_to_many_cnt))
-        self.logger.debug("parse_querymany qm_struct: {}".format(qm_struct.keys()))
+        # self.logger.debug("parse_querymany num qm_struct keys: {}".format(len(qm_struct.keys())))
+        # self.logger.info("parse_querymany running one_to_many_cnt: {}".format(self.one_to_many_cnt))
+        # self.logger.debug("parse_querymany qm_struct: {}".format(qm_struct.keys()))
         return qm_struct
 
     def _parse_h(self, h):
@@ -355,7 +355,7 @@ class BiothingsAPIEdge(DataTransformEdge):
         :param qr: querymany results
         :return:
         """
-        self.logger.debug("QueryMany Structure:  {}".format(qr))
+        # self.logger.debug("QueryMany Structure:  {}".format(qr))
         qm_struct = IDStruct()
         for q in qr['out']:
             query = q['query']

--- a/biothings/hub/datatransform/datatransform_mdb.py
+++ b/biothings/hub/datatransform/datatransform_mdb.py
@@ -76,7 +76,7 @@ class MongoDBEdge(DataTransformEdge):
 
 class DataTransformMDB(DataTransform):
     # Constants
-    batch_size = 1000
+    batch_size = 5000
     default_source = '_id'
 
     def __init__(self, G, *args, **kwargs):

--- a/biothings/tests/keylookup_graphs.py
+++ b/biothings/tests/keylookup_graphs.py
@@ -125,3 +125,24 @@ graph_regex.add_node('bregex')
 
 graph_regex.add_edge('a', 'b', object=MongoDBEdge('b', 'a_id', 'b_id'))
 graph_regex.add_edge('b', 'bregex', object=RegExEdge('b:', 'bregex:'))
+
+###############################################################################
+# PubChem API Graph for Testing
+###############################################################################
+
+graph_pubchem = nx.DiGraph()
+
+graph_pubchem.add_node('inchi')
+graph_pubchem.add_node('pubchem')
+graph_pubchem.add_node('inchikey')
+
+inchikey_fields = [
+    'pubchem.inchi_key',
+    'drugbank.inchi_key',
+    'chembl.inchi_key'
+]
+
+graph_pubchem.add_edge('inchi', 'pubchem',
+                      object=MyChemInfoEdge('pubchem.inchi', 'pubchem.cid'))
+graph_pubchem.add_edge('pubchem', 'inchikey',
+                      object=MyChemInfoEdge('pubchem.cid', inchikey_fields))

--- a/biothings/tests/test_datatransform.py
+++ b/biothings/tests/test_datatransform.py
@@ -4,7 +4,7 @@ biothings.config_for_app(config)
 from biothings.hub.datatransform import DataTransformMDB as KeyLookup
 from biothings.tests.keylookup_graphs import graph_simple, \
     graph_weights, graph_one2many, graph_invalid, graph_mix, \
-    graph_mychem, graph_regex
+    graph_mychem, graph_regex, graph_pubchem
 import unittest
 import biothings.utils.mongo as mongo
 
@@ -292,6 +292,22 @@ class TestDataTransform(unittest.TestCase):
         res_lst = load_document('data/folder/')
         res = next(res_lst)
         self.assertEqual(res['_id'], 'end1')
+
+    def test_pubchem_api(self):
+        """
+        Test 'inchi' to 'inchikey' conversion using mychem.info
+        :return:
+        """
+        doc_lst = [{'_id': 'InChI=1S/C8H9NO2/c1-6(10)9-7-2-4-8(11)5-3-7/h2-5,11H,1H3,(H,9,10)'}]
+
+        @KeyLookup(graph_pubchem, 'inchi', ['inchikey'])
+        def load_document(data_folder):
+            for d in doc_lst:
+                yield d
+
+        res_lst = load_document('data/folder/')
+        res = next(res_lst)
+        self.assertEqual(res['_id'], 'RZVAJINKPMORJF-UHFFFAOYSA-N')
 
     def test_input_source_fields(self):
         """


### PR DESCRIPTION
This branch includes improvements to the DataTransform API based key lookup process.  It includes a unit test verifying that conversion can be processed from 'inchi' to 'inchikey' by way of 'pubchem'.

The module has been tested with the 'pharmgkb' data source in mychem.info.