### PR TITLE
Rename DataTransformMDB to DataTransformNetworkX

### DIFF
--- a/biothings/hub/datatransform/__init__.py
+++ b/biothings/hub/datatransform/__init__.py
@@ -7,8 +7,8 @@ from biothings.hub.datatransform.datatransform import nested_lookup
 # only for testing purpose, this one is not optimized
 #from biothings.hub.datatransform.datatransform_serial import DataTransformSerial
 
-from biothings.hub.datatransform.datatransform_mdb import DataTransformMDB
-from biothings.hub.datatransform.datatransform_mdb import MongoDBEdge
+from biothings.hub.datatransform.datatransform_networkx import DataTransformNetworkX
+from biothings.hub.datatransform.datatransform_networkx import MongoDBEdge
 
 # this involved biothings client dependency, skip it for now
 #from biothings.hub.datatransform.datatransform_api import MyChemInfoEdge

--- a/biothings/hub/datatransform/datatransform_networkx.py
+++ b/biothings/hub/datatransform/datatransform_networkx.py
@@ -88,7 +88,7 @@ class MongoDBEdge(DataTransformEdge):
         return res_id_strct
 
 
-class DataTransformMDB(DataTransform):
+class DataTransformNetworkX(DataTransform):
     """
     Convert document identifiers from one type to another.
     """
@@ -98,7 +98,7 @@ class DataTransformMDB(DataTransform):
 
     def __init__(self, G, *args, **kwargs):
         """
-        The DataTransform MDB module was written as a decorator class
+        The DataTransformNetworkX module was written as a decorator class
         which should be applied to the load_data function of a
         Biothings Uploader.  The load_data function yields documents,
         which are then post processed by call and the 'id' key

--- a/biothings/tests/keylookup_graphs.py
+++ b/biothings/tests/keylookup_graphs.py
@@ -2,7 +2,7 @@ import biothings_client
 import networkx as nx
 
 from biothings.hub.datatransform.datatransform_api import MyChemInfoEdge, MyGeneInfoEdge
-from biothings.hub.datatransform.datatransform_mdb import MongoDBEdge
+from biothings.hub.datatransform.datatransform_networkx import MongoDBEdge
 from biothings.hub.datatransform.datatransform import RegExEdge
 
 ###############################################################################

--- a/biothings/tests/test_datatransform.py
+++ b/biothings/tests/test_datatransform.py
@@ -1,7 +1,7 @@
 import config, biothings
 biothings.config_for_app(config)
 
-from biothings.hub.datatransform import DataTransformMDB as KeyLookup
+from biothings.hub.datatransform import DataTransformNetworkX as KeyLookup
 from biothings.tests.keylookup_graphs import graph_simple, \
     graph_weights, graph_one2many, graph_invalid, graph_mix, \
     graph_mychem, graph_regex


### PR DESCRIPTION
Hopefully this clears up some confusion on DataTransform class naming.  Unit tests pass (except 1, which also fails in origin/master).  We will have to update MyChem.info as well to point to the new class name on import.