### PR TITLE
Update header links

### DIFF
--- a/biothings/hub/webapp/src/App.vue
+++ b/biothings/hub/webapp/src/App.vue
@@ -45,10 +45,10 @@
             </div>
 
 
-            <a class="clickable item" v-for="mitem in menu">
+            <router-link :to="mitem['path']" class="clickable item" v-for="mitem in menu" v-bind:key="mitem.name" exact>
                 <i :class="['ui',mitem['icon'],'icon']"></i>
-                <router-link :to="mitem['path']">{{ mitem['name'] }}</router-link>
-            </a>
+                {{ mitem['name'] }}
+            </router-link>
             <!--a class="clickable item" v-if="has_feature('source') && has_feature('build')">
                 <i class="ui home icon"></i>
                 <router-link to="/">Home</router-link>
@@ -359,7 +359,7 @@
     import StandaloneWizard from './StandaloneWizard.vue';
     import SystemUpgrade from './SystemUpgrade.vue';
 
-    const router = new VueRouter();
+    const router = new VueRouter({linkActiveClass:"active"});
 
     const PING_INTERVAL_MS = 10000;
 


### PR DESCRIPTION
Expands the hitbox of the toolbar's links to the entirety of the button and not just the text, also if the link is an exact match it gives it an "active" class, which shows it greyed out to give better navigation.