### PR TITLE
Fix tooltip 83

### DIFF
--- a/biothings/hub/webapp/src/Build.vue
+++ b/biothings/hub/webapp/src/Build.vue
@@ -52,19 +52,19 @@
             <div class="left aligned description">
                 <p>
                     <div class="ui top attached pointing secondary menu">
-                        <a class="item active" data-tab="sources">Sources</a>
-                        <a class="item" data-tab="stats">Stats</a>
-                        <a class="item" data-tab="logs">Logs</a>
+                        <a class="item active" :data-tab="'sources' + build.build_config.name">Sources</a>
+                        <a class="item" :data-tab="'stats' + build.build_config.name">Stats</a>
+                        <a class="item" :data-tab="'logs' + build.build_config.name">Logs</a>
                     </div>
-                    <div class="ui bottom attached tab segment active" data-tab="sources">
+                    <div class="ui bottom attached tab segment active" :data-tab="'sources' + build.build_config.name">
                         <build-sources v-bind:build="build"></build-sources>
                     </div>
 
-                    <div class="ui bottom attached tab segment" data-tab="stats">
+                    <div class="ui bottom attached tab segment" :data-tab="'stats' + build.build_config.name">
                         <build-stats v-bind:build="build"></build-stats>
                     </div>
 
-                    <div class="ui bottom attached tab segment" data-tab="logs">
+                    <div class="ui bottom attached tab segment" :data-tab="'logs' + build.build_config.name">
                         <build-logs v-bind:build="build"></build-logs>
                     </div>
                 </p>
@@ -169,7 +169,7 @@ export default {
     props: ['pbuild','color'],
     mounted() {
         $('.menu .item')
-        .tab()
+        .tab({context: 'parent'})
         ;
     },
     created() {

--- a/biothings/hub/webapp/src/DataSource.vue
+++ b/biothings/hub/webapp/src/DataSource.vue
@@ -54,17 +54,17 @@
             </span>
             <span v-else>
                 <div class="ui icon buttons left floated mini">
-                    <button class="ui button" v-on:click="do_dump" v-if="source.download">
+                    <button class="ui button" v-on:click="do_dump" v-bind:class="{ yellow: (download_status == 'downloading')}" v-if="source.download">
                         <i class="download cloud icon labeled" data-content="Dump" ></i>
                     </button>
                 </div>
                 <div class="ui icon buttons left floated mini">
-                    <button class="ui button" v-on:click="do_upload" v-if="source.upload">
+                    <button class="ui button" v-on:click="do_upload" v-bind:class="{ yellow: (upload_status == 'uploading')}" v-if="source.upload">
                         <i class="database icon labeled" data-content="Upload"></i>
                     </button>
                 </div>
                 <div class="ui icon buttons left floated mini">
-                    <button class="ui button" v-on:click="inspect">
+                    <button class="ui button" v-on:click="inspect" v-bind:class="{ yellow: (inspect_status == 'inspecting')}">
                         <i class="unhide icon labeled" data-content="Inspect"></i>
                     </button>
                 </div>
@@ -120,7 +120,6 @@ export default {
     mounted () {
         $('select.dropdown').dropdown();
         $('.plugin-popup').popup();
-        $('.labeled').popup();
     },
     data() {
         return {


### PR DESCRIPTION
- makes tabs for each build on the Builds page independent
- removes tooltips from buttons on the Sources page (which were negatively interfering with other more critical tooltips)
- buttons on the Sources page will be highlighted yellow if their action is being performed (e.g., if a source is currently uploading, the upload button will turn yellow)