### PR TITLE
Documentation improvements

### DIFF
--- a/biothings/hub/webapp/src/MappingMap.vue
+++ b/biothings/hub/webapp/src/MappingMap.vue
@@ -5,7 +5,7 @@
         <h3 class="center aligned" v-else-if="map_origin == 'master'">Registered mapping</h3>
         <h3 class="center aligned" v-else-if="map_origin == 'build'">Merged mapping</h3>
         <div class="center aligned" :class="actionable">
-            <button class="ui labeled mini icon button" 
+            <button class="ui labeled mini icon button"
                 v-if="map && !read_only
                 && !map['errors']
                 && !map['pre-mapping']"
@@ -133,7 +133,7 @@
                                 <i class="right triangle icon"></i>
                                 <div class="content">
                                     <div class="description">
-                                      ElasticSearch field data type can be changed if needed. See 
+                                      ElasticSearch field data type can be changed if needed. See
                                       <a target="_blank" href="https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html">
                                         Field datatypes
                                       </a> for more information.
@@ -172,7 +172,7 @@
             </div>
             <div class="content">
                 <p>Are you sure you want to commit mapping from inspection?</p>
-                <p>This will be replace current registered one.</p>
+                <p>This will replace current registered one.</p>
             </div>
             <div class="actions">
                 <div class="ui red basic cancel button">
@@ -280,7 +280,7 @@ export default {
         copied_to_all: {
             cache : false,
             get : function() {
-                if("copy_to" in this.submap 
+                if("copy_to" in this.submap
                     //&& typeof this.submap["copy_to"] == "array"
                     &&  this.submap["copy_to"].indexOf("all") != -1) {
                     return true;

--- a/docs/doc/hub_tutorial.rst
+++ b/docs/doc/hub_tutorial.rst
@@ -2,7 +2,7 @@
 BioThings Hub
 *************
 
-.. note:: this tutorial uses an old/deprecated version of BioThings SDK. It will be updated very soon.
+.. note:: This tutorial uses an old/deprecated version of BioThings SDK. It will be updated very soon.
 
 In this tutorial, we will build the whole process, or "hub", which produces the data
 for Taxonomy BioThings API, accessible at `<t.biothings.io>`_. This API serves information
@@ -1420,4 +1420,3 @@ Coming soon!
 Full updated and maintained code for this hub is available here: https://github.com/biothings/biothings.species
 
 Also, taxonomy BioThings API can be queried as this URL: http://t.biothings.io
-

--- a/docs/doc/standalone.rst
+++ b/docs/doc/standalone.rst
@@ -2,13 +2,13 @@
 BioThings Standalone
 ####################
 
-This step-by-step guide shows how to use Biothings standalone instances. Standalones instances
-are based on Docker containers and provide and fully pre-configured, ready-to-use Biothings API
+This step-by-step guide shows how to use Biothings standalone instances. Standalone instances
+are based on Docker containers and provide a fully pre-configured, ready-to-use Biothings API
 that can easily be maintained and kept up-to-date. The idea is, for any user, to be able to run
-her own APIs locally, fulfulling differents needs:
+his/her own APIs locally and fulfill differents needs:
 
-* keep all APIs requests private and local to your own server
-* enriching existing and publicly available data found on our APIs with some private data
+* keep all API requests private and local to your own server
+* enrich existing and publicly available data found on our APIs with some private data
 * run API on your own architecture to perform heavy queries that would sometimes be throttled out from
   online services
 
@@ -597,4 +597,3 @@ Logs are available in ``/data/mygene.info/logs/``. You can have a look at:
 * and ``hub_*.log`` files for general logs about the hub process
 
 Finally, you can report issues and request for help, by joining Biothings Google Groups (https://groups.google.com/forum/#!forum/biothings)
-

--- a/docs/doc/studio.rst
+++ b/docs/doc/studio.rst
@@ -4,8 +4,7 @@ BioThings Studio
 
 **BioThings Studio** is a pre-configured environment used to build and administer BioThings API.
 At its core is the **Hub**, a backend service responsible for maintaining data up-to-date,
-producing data releases and update API frontends.
+producing data releases, and updating API frontends.
 
 .. include:: studio_tutorial.rst
 .. include:: studio_guide.rst
-

--- a/docs/doc/studio_guide.rst
+++ b/docs/doc/studio_guide.rst
@@ -249,7 +249,7 @@ By clicking on the cog icon in the bar on the right, **Hub** configuration can b
    :width: 100%
 
 All parameters must be entered in a JSON format. Ex: double quotes for strings, square brackets to define lists, etc. A changed parameter can be saved using
-the "Save" button, available for each parameter. The "Reset" button can be used to switch it backto the original default value that was defined in the configuration files.
+the "Save" button, available for each parameter. The "Reset" button can be used to switch it back to the original default value that was defined in the configuration files.
 
 Ex: Update Hub's name
 
@@ -364,7 +364,7 @@ A manifest file is defined like this:
 
 
 
-``self`` refers to the actual dumper instance, which is one of either a ``biothings.hub.dataload.dumper.HTTPDumper`` or a ``biothings.hub.dataload.dumper.FTPDumper``, depending
+``self`` refers to the actual dumper instance of either ``biothings.hub.dataload.dumper.HTTPDumper`` or ``biothings.hub.dataload.dumper.FTPDumper``, depending
 on the protocol. All properties and methods from the instance are available, specifically:
 
   * ``self.client``, the actual underlying client used to download files, which is either a ``request.Session`` or a ``ftplib.FTP`` instance, and should be preferred

--- a/docs/doc/studio_guide.rst
+++ b/docs/doc/studio_guide.rst
@@ -2,10 +2,10 @@
 Developer's guide
 *****************
 
-This section provides both an overview and detailed information abouth **BioThings Studio**,
+This section provides both an overview and detailed information about **BioThings Studio**,
 and is specifically aimed to developers who like to know more about internals.
 
-A complementary `tutorial <studio_tutorial.html>`_ is also available, explaining how to setup and use **BioThings Studio**,
+A complementary `tutorial <studio_tutorial.html>`_ is also available, explaining how to set up and use **BioThings Studio**,
 step-by-step, by building an API from a flat file.
 
 ========================
@@ -30,7 +30,7 @@ in the following diagram:
 * data is first downloaded locally using `dumpers`
 * `parsers` will then convert data into JSON documents, those will be stored in a Mongo database using `uploaders`
 * when using multiple sources, data can be combined together using `mergers`
-* data releases are then created by either indexing data to an ElasticSearch cluster with `indexers`, or
+* data releases are then created either by indexing data to an ElasticSearch cluster with `indexers`, or
   by computing the differences between the current release and previous one, using `differs`, and applying these
   differences using `syncers`
 
@@ -41,9 +41,9 @@ different available clients, and is out of this document's scope.
 BioThings Studio
 ^^^^^^^^^^^^^^^^
 
-The architecture and different software involved in this system can be quite intimidating. To help
+The architecture and different software involved in this system can be quite intimidating. To help,
 the whole service is packaged as a pre-configured application, **BioThings Studio**. A docker image is available
-Docker Hub registry, and be pulled using:
+Docker Hub registry, and can be pulled using:
 
 .. code:: bash
 
@@ -52,18 +52,20 @@ Docker Hub registry, and be pulled using:
 .. image:: ../_static/hubstack.png
    :width: 100%
 
-A **BioThings Studio** instance expose several services on different ports:
+A **BioThings Studio** instance exposes several services on different ports:
 
 * **8080**: **BioThings Studio** web application port
 * **7022**: **BioThings Hub** SSH port
 * **7080**: **BioThings Hub** REST API port
+* **7081**: **BioThings Hub** read-only REST API port
 * **9200**: ElasticSearch port
 * **27017**: MongoDB port
 * **8000**: BioThings API, once created, it can be any non-priviledged (>1024) port
 * **9000**: Cerebro, a webapp used to easily interact with ElasticSearch clusters
+* **60080**: Code-Server, a webapp used to directly edit code in the container
 
 **BioThings Hub** and the whole backend service can be accessed through different options according to some
-of these services
+of these services:
 
 * a web application allows interaction with the most used elements of the service (port 8080)
 * a console, accessible through SSH, gives access to more commands, for advanced usage (port 7022)
@@ -77,57 +79,58 @@ Who should use BioThings Studio ?
 **BioThings Studio** can be used in different scenarios:
 
 * you want to contribute to an existing BioThings API by integrating a new data source
-* you want to run your own BioThings API but don't want to have to install all the dependencies and
+* you want to run your own BioThings API but don't want to install all the dependencies and
   learn how to configure all the sub-systems
 
 
 Filesystem overview
 ^^^^^^^^^^^^^^^^^^^
 
-Several locations on the filesystem are important to notice, when it comes to change default configuration or troubleshoot the application.
+Several locations on the filesystem are important, when it comes to change default configuration or troubleshoot the application:
 
-* **Hub** (backend service) is running under ``biothings`` user, running code is located in ``/home/biothings/biothings_studio``. It heavely relies on
+* **Hub** (backend service) is running under ``biothings`` user, running code is located in ``/home/biothings/biothings_studio``. It heavily relies on
   BioThings SDK located in ``/home/biothings/biothings.api``.
 * Several scripts/helpers can be found in ``/home/biothings/bin``:
 
-  - ``run_studio`` is used to run the Hub in a tmux session. If a session is already running, it will first kill it and create new one. We don't have
+  - ``run_studio`` is used to run the Hub in a tmux session. If a session is already running, it will first kill the session and create a new one. We don't have
     to run this manually when the studio first starts, it is part of the starting sequence.
   - ``update_studio`` is used to fetch the latest code for **BioThings Studio**
-  - ``update_biotnings``, same as above but for BioThings SDK
+  - ``update_biothings``, same as above but for BioThings SDK
 
 * ``/data`` contains several important folders:
 
   - ``mongodb`` folder, where MongoDB server stores its data
   - ``elasticsearch`` folder, where ElasticSearch stores its data
-  - ``biothings_studio`` folder, containing different sub-folders used by the **Hub**
+  - ``biothings_studio`` folder, containing different sub-folders used by the **Hub**:
 
     - ``datasources`` contains data downloaded by the different ``dumpers``, it contains sub-folders named according to the datasource's name.
       Inside the datasource folder can be found the different releases, one per folder.
-    - ``dataupload`` is where data is stored when uploading data to the Hub (see below dedicated section for more).
+    - ``dataupload`` is where data is stored when uploaded to the Hub (see below dedicated section for more).
     - ``logs`` contains all log files produced by the **Hub**
     - ``plugins`` is where data plugins can be found (one sub-folder per plugin's name)
 
 .. note:: Instance will store MongoDB data in `/data/mongodb`, ElasticSearch data in `/data/elasticsearch/` directory,
-   and downloaded data and logs in `/data/biothings_studio`. Those locations could require extra disk space,
-   if needed Docker option ``-v`` can be used to mount a directory from the host, inside the container.
-   Please refer to Docker documentation. It's also important to give enough permissions so the differences services
+   and downloaded data and logs in `/data/biothings_studio`. Those locations could require extra disk space;
+   if necessary, Docker option ``-v`` can be used to mount a directory from the host, inside the container.
+   Please refer to Docker documentation. It's also important to give enough permissions so the different services
    (MongoDB, ElasticSearch, NGNIX, BioThings Hub, ...) can actually write data on the docker host.
 
 Configuration files
 ^^^^^^^^^^^^^^^^^^^
 
 **BioThings Hub** expects some configuration variables to be defined first, in order to properly work. In most **BioThings Studio**, a ``config_hub.py`` defines
-those parameters, either by providing default value(s), or by setting it as ``ConfigurationError`` exception. In that latter case, it means no defaults can be used
+those parameters, either by providing default value(s), or by setting them as ``ConfigurationError`` exception. In the latter case, it means no defaults can be used
 and user/developer has to define it. A final ``config.py`` file must be defined, it usually imports all parameters from ``config_hub.py`` (``from config_hub import *``).
 That ``config.py`` *has* to be defined before the **Hub** can run.
 
-.. note:: This process is only required when implementing or initializing a Hub from scratch. All **BioThings Studio** applications comes with that file defined, the **Hub**
+.. note:: This process is only required when implementing or initializing a Hub from scratch. All **BioThings Studio** applications come with that file defined, and the **Hub**
    is ready to be used.
 
 It's also possible to override parameters directly from the webapp/UI. In that case, new parameters' values are stored in the internal Hub database. Upon start, **Hub** will check
-that database and supersed any values that are defined directly in the python configuration files. This process is handled by class ``biothings.ConfigurationManager``.
+that database and supersede any values that are defined directly in the python configuration files. This process is handled by class ``biothings.ConfigurationManager``.
 
 Finally, a special (simple) dialect can be used while defining configuration parameters, using special markup within comments above declaration. This allows to:
+
 * provide documentation for parameters
 * put parameters under different categories
 * mark a parameter as read-only
@@ -326,7 +329,7 @@ A manifest file is defined like this:
   is passed to `pip install` command line. If one dependency installation fails, the plugin is invalidated. Alternately, a single string can be passed, instead of a list.
 - a *dumper* section specifies how to download the actual data.
 
-  * *data_url* specifies where to download the data from. It can be a URL (string) or a list of URLs (list of strings). Currently supported protocols are **http(s)** and **ftp**. 
+  * *data_url* specifies where to download the data from. It can be a URL (string) or a list of URLs (list of strings). Currently supported protocols are **http(s)** and **ftp**.
     URLs must point to individual files (no wildcards) and only one protocol is allowed within a list of URLs (no mix of URLs using htttp and ftp are allowed). All files
     are download in a data folder, determined by ``config.DATA_ARCHIVE_ROOT``/<plugin_name>/<release>
 

--- a/docs/doc/studio_guide.rst
+++ b/docs/doc/studio_guide.rst
@@ -174,19 +174,19 @@ Overview of BioThings Studio web application
 ============================================
 
 **BioThings Studio** web application can simply be accessed using any browser pointing to port 8080. The home page
-shows a summary of current data recent updates. For now, it's pretty quiet since we didn't integrate any data yet.
+shows a summary of current data and recent updates. For now, it's pretty quiet since we didn't integrate any data yet.
 
 
 .. image:: ../_static/homeempty.png
 
 Let's have a quick overview of the different elements accessible through the webapp. On the top left is the connection widget.
-By default, **BioThings Studio** webapp will connect to the hub API through port 7080, the one running with docker. But the webapp
-is a static web page so you can access any other Hub API by configuring a new connection:
+By default, **BioThings Studio** webapp will connect to the hub API through port 7080, the one running within docker. But the webapp
+is a static web page, so you can access any other Hub API by configuring a new connection:
 
 .. image:: ../_static/connectionlist.png
    :width: 250px
 
-Enter the Hub API URL, ``http://<host>:<port>`` (you can omit ``http://``, the webapp will use that scheme by default)
+Enter the Hub API URL, ``http://<host>:<port>`` (you can omit ``http://``, the webapp will use that scheme by default):
 
 .. image:: ../_static/connectioncreate.png
 
@@ -197,7 +197,7 @@ but cannot be edited.
    :width: 250px
 
 Following are several tabs giving access to the main steps involved in building a BioThings API.
-We'll get into those in more details while we create our
+We'll get into those in more details while creating our
 new API. On the right, we have different information about jobs and resources:
 
 .. figure:: ../_static/commands.png
@@ -215,7 +215,7 @@ new API. On the right, we have different information about jobs and resources:
 .. figure:: ../_static/threads.png
    :width: 600px
 
-   **BioThings Hub** also uses threads for parallelization, their activity will be show here.
+   **BioThings Hub** also uses threads for parallelization, their activity will be shown here.
    Number of queued jobs, waiting for a free process or thread, is showned, as well as the total amount of memory the **Hub**
    is currenly using
 
@@ -227,16 +227,15 @@ new API. On the right, we have different information about jobs and resources:
 .. figure:: ../_static/loader.png
    :width: 600px
 
-   A first circle shows the page loading activity. Gray means nothing active, flashing blue means webapp is loading information from the Hub, and red means an
-   error occured (error should be found in either notifications or by openin the logs from the bottom right corner).
+   The first circle shows the page loading activity. Gray means nothing active, flashing blue means webapp is loading information from the Hub, and red means an
+   error occured (error should be found either in notifications or by opening the logs from the bottom right corner).
 
    The next button with a cog icon gives access to the configuration and is described in the next section.
 
 .. figure:: ../_static/websocket.png
    :width: 600px
 
-   Finally, a logo shows the websocket connection status (green power button means "connected", red plug means "not connected")
-   on average)
+   Finally, a logo shows the websocket connection status (green power button means "connected", red plug means "not connected").
 
 =============
 Configuration
@@ -249,8 +248,8 @@ By clicking on the cog icon in the bar on the right, **Hub** configuration can b
 .. figure:: ../_static/configform.png
    :width: 100%
 
-Any parameter must be entered in a JSON format. Ex: double quotes for strings, square brackets to define lists, etc... Once a parameter has been changed, change can be saved using
-the "Save" button, available for each parameters. The "Reset" button can be used to switch back the original, default value that was defined in the configuration files.
+All parameters must be entered in a JSON format. Ex: double quotes for strings, square brackets to define lists, etc. A changed parameter can be saved using
+the "Save" button, available for each parameter. The "Reset" button can be used to switch it backto the original default value that was defined in the configuration files.
 
 Ex: Update Hub's name
 
@@ -262,8 +261,7 @@ First enter the new name, for paramerer ``HUB_NAME``. Because the value has chan
 .. figure:: ../_static/savehubname.png
    :width: 200px
 
-Upon validation, a green check mark is shown, and because the value is not the default one, the "Reset" button is now available. Clicking on it will switch back the
-value for that parameter to the original, default one.
+Upon validation, a green check mark is shown, and because the value is not the default one, the "Reset" button is now available. Clicking on it will switch the parameter's value back to its original default one.
 
 .. figure:: ../_static/resethubname.png
    :width: 200px
@@ -324,17 +322,17 @@ A manifest file is defined like this:
 
 - a *version* defines the specification version the manifest is using. Currently, version 0.2 should be used. This is not the version of the datasource itself.
 - an optional (but highly recommended) *__metadata__* key provides information about the datasource itself, such as a website, a link to its license, the license name.
-  This information, when provided, are displayed in the /metadata endpoint of the resulting API.
+  This information, when provided, is displayed in the ``/metadata`` endpoint of the resulting API.
 - a *requires* section, optional, describes dependencies that should be installed for the plugin to work. This uses `pip` behind the scene, and each element of that list
   is passed to `pip install` command line. If one dependency installation fails, the plugin is invalidated. Alternately, a single string can be passed, instead of a list.
-- a *dumper* section specifies how to download the actual data.
+- a *dumper* section specifies how to download the actual data:
 
   * *data_url* specifies where to download the data from. It can be a URL (string) or a list of URLs (list of strings). Currently supported protocols are **http(s)** and **ftp**.
-    URLs must point to individual files (no wildcards) and only one protocol is allowed within a list of URLs (no mix of URLs using htttp and ftp are allowed). All files
+    URLs must point to individual files (no wildcards), and only one protocol is allowed within a list of URLs (no mix of URLs using http and ftp are allowed). All files
     are download in a data folder, determined by ``config.DATA_ARCHIVE_ROOT``/<plugin_name>/<release>
 
-  * *uncompress*: once downloaded, this flag, if set to true, will uncompress all supported archived found in the data folder.
-    Currently supported format are: ``*.zip``, ``*.gz``, ``*.tar.gz`` (includes untar step)
+  * *uncompress*: once data is downloaded, this flag, if set to true, will uncompress all supported archives found in the data folder.
+    Currently supported formats are: ``*.zip``, ``*.gz``, ``*.tar.gz`` (includes untar step)
 
   * *schedule* will trigger the scheduling of the dumper, so it automatically checks for new data on a regular basis. Format is the same as crontabs, with the
     addition of an optional sixth parameter for scheduling by the seconds.
@@ -350,9 +348,9 @@ A manifest file is defined like this:
     - ``MDTM`` ftp command if URL is FTP-based.
 
     If a list of URLs is specified in *data_url*, the last URL is the one used to determine the release.
-    If none of those are available, or not satisfactory, a *release* section can be specified, and should point to a python module and a function name
+    If none of those are available or satisfactory, a *release* section can be specified, and should point to a python module and a function name
     following this format: ``module:function_name``. Within this module, function has the following signature and should return the release, as a string.
-    ``set_release`` is a reserver name and must not be used.
+    ``set_release`` is a reserved name and must not be used.
 
 .. code:: python
 
@@ -366,10 +364,10 @@ A manifest file is defined like this:
 
 
 
-``self`` refers to the actual dumper instance, that is, either a ``biothings.hub.dataload.dumper.HTTPDumper`` or a ``biothings.hub.dataload.dumper.FTPDumper`` depending
-on the protocol. All properties, methods from the instance are available, specifically:
+``self`` refers to the actual dumper instance, which is one of either a ``biothings.hub.dataload.dumper.HTTPDumper`` or a ``biothings.hub.dataload.dumper.FTPDumper``, depending
+on the protocol. All properties and methods from the instance are available, specifically:
 
-  * ``self.client``, the actual underlying client used to download files, which is either a ``request.Session`` or ``ftplib.FTP`` instance, and should be prefered
+  * ``self.client``, the actual underlying client used to download files, which is either a ``request.Session`` or a ``ftplib.FTP`` instance, and should be preferred
     over initializing a new connection/client.
   * ``self.SRC_URLS``, containing the list of URLs (if only one URL was specified in *data_url*, this will be a list of one element), which is commonly
     used to inspect and possibly determine the release.
@@ -377,7 +375,7 @@ on the protocol. All properties, methods from the instance are available, specif
 
 - an *uploader* section specifies how to parse and store (upload):
 
-  * *parser* key defined a module and a function name within that module. Format: ``module:function_name``. Function has the following signature and return a list of dictionary
+  * *parser* key defines a module and a function name within that module. Format: ``module:function_name``. Function has the following signature and returns a list of dictionary
   (or ``yield`` dictionaries) containing at least a ``_id`` key reprensenting a unique identifier (string) for this document:
 
 
@@ -391,7 +389,7 @@ on the protocol. All properties, methods from the instance are available, specif
 ``data_folder`` is the folder containing the previously downloaded (dumped) data, it is automatically set to the latest release available. Note the function doesn't
 take an filename as input, it should select the file(s) to parse.
 
-  * *on_duplicates* defines the strategy to use when duplicated record are found (according to the ``_id`` key):
+  * *on_duplicates* defines the strategy to use when duplicated records are found (according to the ``_id`` key):
 
     - ``error`` (default) will raise an exception if duplicates are found
     - ``ignore`` will skip any duplicates, only the first one found will be store
@@ -403,7 +401,7 @@ take an filename as input, it should select the file(s) to parse.
     be used.
 
   * *mapping* points to a ``module:classmethod_name`` that can be used to specify a custom ElasticSearch mapping. Class method must return a python dictionary with a
-    valid mapping. ``get_mapping`` is a reserved name and must not be used. There's no need to add ``@classmethod`` decorator, **Hub** will take care of it, the first
+    valid mapping. ``get_mapping`` is a reserved name and must not be used. There's no need to add ``@classmethod`` decorator, **Hub** will take care of it. The first
     and only argument is a class. Ex:
 
 .. code:: python
@@ -421,7 +419,7 @@ take an filename as input, it should select the file(s) to parse.
 
 
 .. note:: Please see https://github.com/sirloon/mvcgi for a simple plugin definition. https://github.com/sirloon/gwascatalog will show how to use
-   the ``release`` key and https://github.com/sirloon/FIRE will demonstrate the parallelization in the uploader section.
+   the ``release`` key; https://github.com/sirloon/FIRE will demonstrate the parallelization in the uploader section.
 
 
 2. "Advanced" data plugins
@@ -431,25 +429,25 @@ This type of plugins is more advanced in the sense that it's plain python code. 
 dumpers and uploaders as python class, inheriting from BioThings SDK components. These plugins can be written from scratch, they're "advanced" because they require more knowledge about
 BioThings SDK.
 
-In the root folder (local folder or remote git repository), a ``__init__.py`` is expected to be found, and should
-contains imports for one dumper, and one or more uploaders.
+In the root folder (local folder or remote git repository), a ``__init__.py`` is expected, and should
+contain imports for one dumper, and one or more uploaders.
 
-An example of advanced data plugin can found at https://github.com/sirloon/mvcgi_advanced.git. It's coming from "mvcgi" manifest-based plugin, where code was exported.
+An example of advanced data plugin can be found at https://github.com/sirloon/mvcgi_advanced.git. It comes from "mvcgi" manifest-based plugin, where code was exported.
 
 
 =========================
 Hooks and custom commands
 =========================
 
-While it's possible to define custom commands for the Hub console, by deriving class ``biothings.hub.HubServer``, there's also an easy way to enrich existing commands using **hooks**.
-A **hook** is a python file located in ``HOOKS_FOLDER`` (defaulting to ``./hooks/``). When the Hub starts, it inspects this folder and "inject" hook's namespace into its console. Everything
+While it's possible to define custom commands for the Hub console by deriving class ``biothings.hub.HubServer``, there's also an easy way to enrich existing commands using **hooks**.
+A **hook** is a python file located in ``HOOKS_FOLDER`` (defaulting to ``./hooks/``). When the Hub starts, it inspects this folder and "injects" hook's namespace into its console. Everything
 available from within the hook file becomes available in the console. On the other hand, hook can use any commands available in the Hub console.
 
-**Hooks** provides an easy way to "program" the Hub, based on existing commands. The following example defines a new command, which will archive any builds older than X days. Code can be
+**Hooks** provide an easy way to "program" the Hub, based on existing commands. The following example defines a new command, which will archive any builds older than X days. Code can be
 found at https://github.com/sirloon/auto_archive_hook.git. File ``auto_archive.py`` should be copied into ``./hooks/`` folder. Upon restart, a new command named ``auto_archive`` is now
 part of the Hub. It's also been scheduled automatically using ``schedule(...)`` command at the end of the hook.
 
-The auto_archive function uses several existing Hub commands:
+The ``auto_archive`` function uses several existing Hub commands:
 
 - ``lsmerge``: when given a build config name, returns a list of all existing build names.
 - ``archive``: will delete underlying data but keep existing metadata for a given build name

--- a/docs/doc/studio_tutorial.rst
+++ b/docs/doc/studio_tutorial.rst
@@ -1196,7 +1196,7 @@ be useful to troubleshoot an issue. Typing ``help()``, or even passing a command
 
 On a lower level, make sure all services are running in the docker container. Enter the container with
 ``docker exec -ti studio /bin/bash`` and type ``netstat -tnlp``, you should see services running on ports
-(see usual running `services <studio_guide.html#services-check>`_). If services running on port 7080 or 7022 aren't running, it means the
+(see usual running `services <studio_guide.html#services-check>`_). If services on ports 7080 and 7022 aren't running, it means the
 **Hub** has not started. If you just started the instance, wait a little more as services may take a while
 before they're fully started and ready.
 

--- a/docs/doc/studio_tutorial.rst
+++ b/docs/doc/studio_tutorial.rst
@@ -58,17 +58,17 @@ Installation
 
   $ docker pull biothings/biothings-studio:0.2b
 
-A **BioThings Studio** instance expose several services on different ports:
+A **BioThings Studio** instance exposes several services on different ports:
 
 * **8080**: **BioThings Studio** web application port
 * **7022**: **BioThings Hub** SSH port
 * **7080**: **BioThings Hub** REST API port
-* **7081°°: **BioThings Hub** REST API port, read-only access
+* **7081**: **BioThings Hub** REST API port, read-only access
 * **9200**: ElasticSearch port
 * **27017**: MongoDB port
 * **8000**: BioThings API, once created, it can be any non-priviledged (>1024) port
-* **9000**: `Cerebro <https://github.com/lmenezes/cerebro>`_, a webapp used to easily interact with ElasticSearch clusters 
-* **60080**: `Code-Server <https://github.com/cdr/code-server>`_, a webapp used to directly edit code in the container 
+* **9000**: `Cerebro <https://github.com/lmenezes/cerebro>`_, a webapp used to easily interact with ElasticSearch clusters
+* **60080**: `Code-Server <https://github.com/cdr/code-server>`_, a webapp used to directly edit code in the container
 
 We will map and expose those ports to the host server using option ``-p`` so we can access BioThings services without
 having to enter the container:
@@ -83,10 +83,10 @@ having to enter the container:
 
 .. note:: Biothings Studio and the Hub are not designed to be publicly accessible. Those ports should **not** be exposed. When
    accessing the Studio and any of these ports, SSH tunneling can be used to safely access the services from outside.
-   Ex: ``ssh -L 7080:localhost:7080 -L 8080:localhost:8080 user@mydockerserver`` will expose the web application,
-   the REST API, Hub SSH and Cerebro app ports  to your computer, so you can access the webapp using http://localhost:8080, the API using http://localhost:7080,
+   Ex: ``ssh -L 7080:localhost:7080 -L 8080:localhost:8080 -L 7022:localhost:7022 -L 9000:localhost:9000 user@mydockerserver`` will expose the Hub REST API, the web application,
+   the Hub SSH, and Cerebro app ports to your computer, so you can access the webapp using http://localhost:8080, the Hub REST API using http://localhost:7080,
    http://localhost:9000 for Cerebro, and directly type ``ssh -p 7022 biothings@localhost`` to access Hub's internals via the console.
-   See https://www.howtogeek.com/168145/how-to-use-ssh-tunneling for more
+   See https://www.howtogeek.com/168145/how-to-use-ssh-tunneling for more details.
 
 We can follow the starting sequence using ``docker logs`` command:
 
@@ -102,7 +102,7 @@ We can follow the starting sequence using ``docker logs`` command:
   now run webapp
   not interactive
 
-Please refer `Filesystem overview <studio_guide.html#filesystem-overview>`_ and  `Services check <studio_guide.html#services-check>`_ for
+Please refer to `Filesystem overview <studio_guide.html#filesystem-overview>`_ and  `Services check <studio_guide.html#services-check>`_ for
 more details about Studio's internals.
 
 By default, the studio will auto-update its source code to the latest version available and install all required dependencies. This behavior can be skipped
@@ -142,7 +142,7 @@ Parser
 
 In order to ingest this data and make it available as an API, we first need to write a parser. Data is pretty simple, tab-separated files, and we'll
 make it even simpler by using ``pandas`` python library. The first version of this parser is available in branch ``pharmgkb_v1`` at
-https://github.com/sirloon/pharmgkb/blob/pharmgkb_v1/parser.py. After some boiler plate code at the beginning for dependencies and initialization,
+https://github.com/sirloon/pharmgkb/blob/pharmgkb_v1/parser.py. After some boilerplate code at the beginning for dependencies and initialization,
 the main logic is the following:
 
 
@@ -157,8 +157,8 @@ the main logic is the following:
             logging.warning("No gene information for annotation ID '%s'", rec["Annotation ID"])
             continue
         _id = re.match(".* \((.*?)\)",rec["Gene"]).groups()[0]
-        # we'll remove space in keys to make queries easier. Also, lowercase is preferred
-        # for a BioThings API. We'll an helper function from BioThings SDK
+        # We'll remove space in keys to make queries easier. Also, lowercase is preferred
+        # for a BioThings API. We'll use an helper function `dict_convert()` from BioThings SDK
         process_key = lambda k: k.replace(" ","_").lower()
         rec = dict_convert(rec,keyfn=process_key)
         results.setdefault(_id,[]).append(rec)
@@ -168,7 +168,7 @@ the main logic is the following:
         yield doc
 
 
-Our parsing function is named ``load_annotations``, it could be name anything else, but it has to take a folder path ``data_folder``
+Our parsing function is named ``load_annotations``, it could be named anything else, but it has to take a folder path ``data_folder``
 containing the downloaded data. This path is automatically set by the Hub and points to the latest version available. More on this later.
 
 .. code:: python
@@ -204,7 +204,7 @@ We then open and read the TSV file using ``pandas.read_csv()`` function. At this
    'Variant': 'rs1131873'}
 
 Keys are uppercase, for a BioThings API, we like to have them as lowercase. More importantly, we want to remove spaces in those keys
-as querying the API in the end will be hard with spaces. We'll use a special helper from BioThings SDK to process these.
+as querying the API in the end will be hard with spaces. We'll use a special helper function from BioThings SDK to process these.
 
 .. code:: python
 
@@ -224,12 +224,12 @@ in a dictionary indexed by gene ID. The final documents are assembled in the las
         yield doc
 
 
-.. note:: The `_id` key is mandatory and represents a unique identifier for this document. The type must a string. The _id key is
+.. note:: The `_id` key is mandatory and represents a unique identifier for this document. The type must be a string. The _id key is
    used when data from multiple datasources are merged together, that process is done according to its value
    (all documents sharing the same _id from different datasources will be merged together).
 
-.. note:: In this specific example, we read the whole content of this input file in memory, when store annotations per gene. The data itself
-   is small enough to do this, but memory usage always needs to cautiously considered when writing a parser.
+.. note:: In this specific example, we read the whole content of this input file in memory, then store annotations per gene. The data itself
+   is small enough to do this, but memory usage always needs to be cautiously considered when we write a parser.
 
 
 Data plugin
@@ -242,12 +242,12 @@ Parser is ready, it's now time to glue everything together and build our API. We
 * all necessary files supporting the declarations in the manifest, such as a python file containing the parsing function for instance.
 
 This folder must be located in the plugins directory (by default ``/data/biothings_studio/plugins``, where the **Hub** monitors changes and
-reloads itself accordingly to register data plugins. Another way to declare such plugin is to register a github repository,
-containing everything useful for the datasource. This is what we'll do in the following section.
+reloads itself accordingly to register data plugins. Another way to declare such plugin is to register a github repository
+that contains everything useful for the datasource. This is what we'll do in the following section.
 
 .. note:: Whether the plugin comes from a github repository or directly found in the plugins directory doesn't really matter. In the end, the code
-   will be found in that same ``plugins`` directory, whether it comes from a ``git clone`` command while registering the github URL or whether it comes
-   from folder and files manually created in that location. It's however easier, when developing a plugin, to directly work on local files first
+   will be found in that same ``plugins`` directory, whether it comes from a ``git clone`` command while registering the github URL or
+   from folder(s) and file(s) manually created in that location. However, when developing a plugin, it's easier to directly work on local files first
    so we don't have to regurlarly update the plugin code (``git pull``) from the webapp, to fetch the latest code. That said, since the plugin
    is already defined in github in our case, we'll use the github repo registration method.
 
@@ -286,7 +286,7 @@ Let's register that data plugin using the Studio. First, copy the repository URL
 .. image:: ../_static/githuburl.png
    :width: 100%
 
-Moving back to the Studio, click on the |sources| tab, then |menu| icon, this will open a side bar on the left. Click on `New data plugin`, you will be asked to enter the github URL.
+Now go to the Studio web application at http://localhost:8080, click on the |sources| tab, then |menu| icon, this will open a side bar on the left. Click on `New data plugin`, you will be asked to enter the github URL.
 Click "OK" to register the data plugin.
 
 .. image:: ../_static/registerdp.png
@@ -318,7 +318,7 @@ The Hub shows an error though:
    :width: 250px
 
 Indeed, we fetch source code from branch ``master``, which doesn't contain any manifest file. We need to switch to another branch (this tutorial is organized using branches,
-and also it's a perfect oportunity to learn how to use a specific branch/commit using **BioThings Studio**...)
+and also it's a perfect opportunity to learn how to use a specific branch/commit using **BioThings Studio**...)
 
 Let's click on ``pharmgkb`` link, then |plugin|. In the textbox on the right, enter ``pharmgkb_v1`` then click on ``Update``.
 
@@ -369,7 +369,7 @@ We also have new notifications as shown by the red number on the right. Let's ha
    :width: 450px
 
 Going back to the source's details, we can see the `Dumper` has been populated. We now know the
-release number, the data folder, when was the last download, how long it tooks to download the file, etc...
+release number, the data folder, when the last download was, how long it tooks to download the file, etc...
 
 .. image:: ../_static/dumptab.png
    :width: 450px
@@ -425,8 +425,8 @@ Since the collection is very small, inspection is fast. But... it seems like we 
 .. image:: ../_static/fielderr.png
    :width: 350px
 
-This results means documents sometimes have ``notes`` key equal to ``NaN``, and sometimes equal to a string (a splittable string, meaning there are spaces in it).
-This is a problem for ElasticSearch because it wouldn't how to index the data properly. And furthermore, ElasticSearch doesn't allow ``NaN`` values anyway. So we need
+This result means documents sometimes have ``notes`` key equal to ``NaN``, and sometimes equal to a string (a splittable string, meaning there are spaces in it).
+This is a problem for ElasticSearch because it wouldn't index the data properly. And furthermore, ElasticSearch doesn't allow ``NaN`` values anyway. So we need
 to fix the parser. The fixed version is available in branch ``pharmgkb_v2`` (go back to Plugin tab, enter that branch name and update the code).
 The fix consists in `removing key/value <https://github.com/sirloon/pharmgkb/blob/pharmgkb_v2/parser.py#L24>`_ from the records, whenever a value is equal to ``NaN``.
 
@@ -465,13 +465,12 @@ moving forwared, we want to make sure the mapping is valid, let's click on |vali
 .. image:: ../_static/validated.png
    :width: 500px
 
-.. note:: "Validate on test" means **Hub** will send the mapping to ElasticSearch by creating a temporary, empty index to make sure the mapping syntax
-   and content are valid. It's immediately deleted after validation (wheter successful or not). Also, "test" is the name of an environment, by default,
-   and without further manual configuration, this is the only development environment available in the Studio, pointing to embedded ElasticSearch server.
+.. note:: "Validate on localhub" means **Hub** will send the mapping to ElasticSearch by creating a temporary, empty index to make sure the mapping syntax
+   and content are valid. It's immediately deleted after validation (whether successful or not). Also, "localhub" is the default name of an environment.
+   Without further manual configuration, this is the only development environment available in the Studio, pointing to embedded ElasticSearch server.
 
-Everything looks fine, one last step is to "commit" the mapping, meaning we're ok to use this mapping as the official, registered mapping,
-the one that will actually be used by ElasticSearch. Indeed the left side of the page is about inspected mapping, we can re-launch the
-inspection as many time as we want, without impacting active/registered mapping (this is usefull when the data structure changes). Click on
+Everything looks fine, the last step is to "commit" the mapping, meaning we're ok to use this mapping as the official, registered mapping that will actually be used by ElasticSearch. Indeed the left side of the page is about inspected mapping, we can re-launch the
+inspection as many times as we want, without impacting active/registered mapping (this is usefull when the data structure changes). Click on
 |commit| then "OK", and you now should see the final, registered mapping on the right:
 
 .. |commit| image:: ../_static/commit.png
@@ -483,7 +482,7 @@ inspection as many time as we want, without impacting active/registered mapping 
 Build
 ^^^^^
 
-Once we have integrated data and a valid ElasticSeach mapping, we can move forward by creating a build configuration. A `build configuration`
+Once we have integrated data and a valid ElasticSearch mapping, we can move forward by creating a build configuration. A `build configuration`
 tells the **Hub** which datasources should be merged together, and how. Click on |builds| then |menu| and finally, click on |newbuildconf|.
 
 .. |builds| image:: ../_static/builds.png
@@ -499,10 +498,10 @@ tells the **Hub** which datasources should be merged together, and how. Click on
   is about gene annotations, so "gene" it is...
 * open the dropdown list and select the `sources` you want to be part of the merge. We only have one, "pharmgkb"
 * in `root sources`, we can declare which sources are allowed to create new documents in the merged collection, that is merge documents from a
-  datasource, but only if corresponding documents exist in the merged collection. It's usefull if data from a specific source relates to data on
+  datasource, but only if corresponding documents exist in the merged collection. It's useful if data from a specific source relates to data on
   another source (it only makes sense to merge that relating data if the data itself is present). If root sources are declared, **Hub** will first
   merge them, then the others. In our case, we can leave it empty (no root sources specified, all sources can create documents in the merged collection)
-* selecting a builder is optional, but the sake of this tutorial, we'll choose ``LinkDataBuilder``. This special builder will fetch documents directly from
+* selecting a builder is optional, but for the sake of this tutorial, we'll choose ``LinkDataBuilder``. This special builder will fetch documents directly from
   our datasources `pharmgkb` when indexing documents, instead of duplicating documents into another connection (called `target` or `merged` collection). We can
   do this (and save time and disk space) because we only have one datasource here.
 * the other fields are for advanced usage and are out-of-topic for this tutorial
@@ -517,7 +516,7 @@ Click on it and create a new build.
 .. image:: ../_static/newbuild.png
    :width: 100%
 
-You can give a specific name for that build, or let the **Hub** generate one for you. Click "OK", after few seconds, you should see the new build displayed on the page.
+You can give a specific name for that build, or let the **Hub** generate one for you. Click "OK", after a few seconds, you should see the new build displayed on the page.
 
 .. image:: ../_static/builddone.png
    :width: 300px
@@ -535,23 +534,23 @@ If not there yet, open the new created build and go the "Release" tab. This is t
 .. image:: ../_static/newreleaseform.png
    :width: 100%
 
-Since we only have one build available, we can't generate an `incremental` release so we'll have to select `full` this time. Click "OK" to launch the process.
+Since we only have one build available, we can't generate an `incremental` release, so we'll have to select `full` this time. Click "OK" to launch the process.
 
 .. note:: Should there be a new build available (coming from the same configuration), and should there be data differences, we could generate an
    incremental release. In this case, **Hub** would compute a diff between previous and new builds and generate diff files (using `JSON diff`_ format).
-   Incremental releases are usually smaller than full releases, usually take less time to deploy (appying diff data) unless diff content is too big
-   (there's a threshold between using an incremental and a full release, depending on the hardware and the data, because applying a diff requires to first
-   fetch the document from ElasticSearch, patch it, and then save it back)
+   Incremental releases are usually smaller than full releases, usually take less time to deploy (applying diff data) unless diff content is too big
+   (there's a threshold between using an incremental and a full release, depending on the hardware and the data, because applying a diff requires you to first
+   fetch the document from ElasticSearch, patch it, and then save it back).
 
 .. _`JSON diff`: http://www.jsondiff.com/
 
-**Hub** will directly index the data on its locally installed ElasticSearch server (``test`` environment). After few seconds, a new `full` release is created.
+**Hub** will directly index the data on its locally installed ElasticSearch server (``localhub`` environment). After few seconds, a new `full` release is created.
 
 .. image:: ../_static/newfullrelease.png
    :width: 100%
 
-We can easily access ElasticSearch server using the application **Cerebro** which comes pre-configured with the studio. Let's access it through http://localhost:9000/#/connect
-(assuming ports 9200 and 9000 have properly been mapped, as mentioned earlier). **Cerebro** provides an easy to manager ElasticSearch and check/query indices.
+We can easily access ElasticSearch server using the application **Cerebro**, which comes pre-configured with the studio. Let's access it through http://localhost:9000/#/connect
+(assuming ports 9200 and 9000 have properly been mapped, as mentioned earlier). **Cerebro** provides an easy-to-manage ElasticSearch and check/query indices.
 
 Click on the pre-configured server named ``BioThings Studio``.
 
@@ -597,7 +596,7 @@ can be accessed:
 .. image:: ../_static/apirunning.png
    :width: 300px
 
-.. note:: When running, queries such ``/metadata`` and ``/query?q=*`` are provided as examples. They contain a hostname set by Docker though (it's the Docker instance hostname), which probably
+.. note:: When running, queries such ``/metadata`` and ``/query?q=*`` are provided as examples. They contain a hostname set by Docker though (it's the Docker instance's hostname), which probably
    means nothing outside of Docker's context. In order to use the API you may need to replace this hostname by the one actually used to access the
    Docker instance.
 
@@ -1180,16 +1179,16 @@ Troubleshooting
 
 We test and make sure, as much as we can, that the **BioThings Studio** image is up-to-date and running properly. But things can still go wrong...
 
-A good starting point investigating an issue is to look at the logs from the **BioThings Studio**. Make sure connected (green power button on the top right),
+A good starting point investigating an issue is to look at the logs from the **BioThings Studio**. Make sure it's connected (green power button on the top right),
 then click "Logs" button, on the bottom right. You will see logs in real-time (if not connected, it will complain about a disconnected websocket). As you click
-and perform actions through out the web application, you will see log message in that windows, and potentially errors not displayed (or with less details) in the
+and perform actions throughout the web application, you will see log message in that window, and potentially errors not displayed (or with less details) in the
 application.
 
 .. image:: ../_static/logs.png
    :width: 500px
 
-The "Terminal" (click on the bottom left button). gives access to commands you can manually type from the web application. Basically, any action performed clicking on the application
-is converted into a command call. You can even see what commands were launched, which ones are running. This terminal gives also access to more commands, and advanced options that may
+The "Terminal" (click on the bottom left button) gives access to commands you can manually type from the web application. Basically, any action performed clicking on the application
+is converted into a command call. You can even see what commands were launched and which ones are running. This terminal also gives access to more commands, and advanced options that may
 be useful to troubleshoot an issue. Typing ``help()``, or even passing a command name such as ``help(dump)`` will print documentation on available commands and how to use them.
 
 .. image:: ../_static/term.png
@@ -1197,13 +1196,13 @@ be useful to troubleshoot an issue. Typing ``help()``, or even passing a command
 
 On a lower level, make sure all services are running in the docker container. Enter the container with
 ``docker exec -ti studio /bin/bash`` and type ``netstat -tnlp``, you should see services running on ports
-(see usual running `services <studio_guide.html#services-check>`_). If services running on ports 7080 or 7022 aren't running, it means the
+(see usual running `services <studio_guide.html#services-check>`_). If services running on port 7080 or 7022 aren't running, it means the
 **Hub** has not started. If you just started the instance, wait a little more as services may take a while
 before they're fully started and ready.
 
-If after ~1 min, you still don't see the **Hub** running, log to user ``biothings`` and check the starting sequence.
+If after ~1 min, you still don't see the **Hub** running, log in as user ``biothings`` and check the starting sequence.
 
-.. note:: **Hub** is running in a tmux session, under user ``biothings``
+.. note:: **Hub** is running in a tmux session, under user ``biothings``.
 
 .. code:: bash
 
@@ -1236,13 +1235,12 @@ If after ~1 min, you still don't see the **Hub** running, log to user ``biothing
    ['/home/biothings/biothings_studio/hub/dataload/sources',
     '/home/biothings/biothings_studio/plugins']
 
-You should see something looking like this above. If not, you should see the actual error, and depending on the error, you may be able to
+You should see something like above. If not, you should see the actual error, and depending on the error, you may be able to
 fix it (not enough disk space, etc...). **BioThings Hub** can be started again using ``python bin/hub.py`` from within the application
 directory (in our case, ``/home/biothings/biothings_studio``)
 
-.. note:: Press Control-B then D to dettach the tmux session and let the **Hub** running in background.
+.. note:: Press Control-B then D to dettach the tmux session and let the **Hub** run in background.
 
 By default, logs are available in ``/data/biothings_studio/logs/``.
 
-Finally, you can report issues and request for help, by joining Biothings Google Groups (https://groups.google.com/forum/#!forum/biothings)
-
+Finally, you can report issues and request for help, by joining Biothings Google Groups (https://groups.google.com/forum/#!forum/biothings).

--- a/docs/doc/utils.rst
+++ b/docs/doc/utils.rst
@@ -2,7 +2,7 @@
 Utility modules
 ###############
 
-The utility modules under `biothings.utils` provide a collections of utilities used across the BioThings SDK code base.
+The utility modules under `biothings.utils` provides a collections of utilities used across the BioThings SDK code base.
 They also provide a level of abstraction for individual functionalities.
 
 .. toctree::

--- a/docs/doc/utils.rst
+++ b/docs/doc/utils.rst
@@ -2,7 +2,7 @@
 Utility modules
 ###############
 
-The utility modules under `biothings.utils` provides a collections of utilities used across the BioThings SDK code base.
+The utility modules under `biothings.utils` provide a collections of utilities used across the BioThings SDK code base.
 They also provide a level of abstraction for individual functionalities.
 
 .. toctree::


### PR DESCRIPTION
This PR fixes some typos and improved some wordings in the documentation. Most of them are in:
- `docs/doc/studio_tutorial.rst`
- `docs/doc/studio_guide.rst`

There is a minor grammar issue in the text of this JS file:
- `hub/webapp/src/MappingMap.vue`

in which `This will be replace ...` should be `This will replace ...`.

The same issue exists in the following two files too:
- `hub/webapp/dist/assets/js/app.7dd5cf82.js.map`
- `hub/webapp/dist/assets/js/app.7dd5cf82.js`

But since these two files seem to be generated automatically by some JS compilation process,  I didn't modify them.

The invisible trailing spaces on a few lines were removed automatically by my editor (Emacs).
