### PR TITLE
Bottombar changes

### DIFF
--- a/biothings/hub/webapp/src/App.vue
+++ b/biothings/hub/webapp/src/App.vue
@@ -74,16 +74,9 @@
                 </router-link>
             </a-->
 
-            <div class="clickable ui item right" v-if="has_feature('job')">
-              <job-summary></job-summary>
-            </div>
-
-            <div class="clickable ui item" v-if="has_feature('ws')">
-                <event-messages>
+            <div class="ui item right">
+                <event-messages v-if="has_feature('ws')">
                 </event-messages>
-            </div>
-
-            <div class="ui item">
                 <loader></loader>
                 <div id="settings" v-if="has_feature('config')">
                     <button class="mini circular ui icon button" @click="openConfig">
@@ -208,11 +201,18 @@
                   Terminal
               </a>
             </div>
+
+
             <div class="right menu">
+              <a class="ui segment mini grey inverted jobs" v-if="has_feature('job')">
+                  <job-summary></job-summary>
+              </a>
+
               <a class="clickable logs item" v-if="has_feature('ws')">
                   <i class="bell outline icon"></i>
                   Logs
               </a>
+            </div>
           </div>
 
           <div class="ui terminal popup top left transition hidden" style="width:50%;">
@@ -1197,9 +1197,13 @@
         margin-right: 2em !important;
     }
 
-    ; very small buttons
+    /*; very small buttons*/
     .tinytiny {
         padding: .5em 1em .5em;
         font-size: .6em;
+    }
+
+    .segment.jobs {
+        margin:0;
     }
 </style>

--- a/biothings/hub/webapp/src/JobSummary.vue
+++ b/biothings/hub/webapp/src/JobSummary.vue
@@ -6,7 +6,7 @@
         <i class="settings icon"></i>
         {{num_commands}}
     </button>
-    <div class="ui commands popup top left transition hidden">
+    <div class="ui commands popup transition hidden">
         <commands-list></commands-list>
     </div>
     <!-- jobs (processes) -->
@@ -16,7 +16,7 @@
         <i class="rocket icon"></i>
         {{job_manager.queue ? job_manager.queue.process.running.length : '?'}}/{{job_manager.queue ? job_manager.queue.process.max : '?'}}
     </button>
-    <div class="ui processes popup top left transition hidden">
+    <div class="ui processes popup transition hidden">
         <processes-list v-bind:processes="processes"></processes-list>
     </div>
     <!-- jobs (threads) -->
@@ -25,25 +25,25 @@
       <i class="lightning icon"></i>
       {{job_manager.queue ? job_manager.queue.thread.running.length : '?'}}/{{job_manager.queue ? job_manager.queue.thread.max : '?' }}
     </button>
-    <div class="ui threads popup top left transition hidden">
+    <div class="ui threads popup transition hidden">
         <threads-list v-bind:threads="threads"></threads-list>
     </div>
     <!-- jobs (pendings) -->
-    <div class="ui small grey label"
+    <button class="ui compact labeled icon button tiny"
       data-tooltip="Number of queued jobs"
-      data-position="bottom center"
+      data-position="top right"
       v-if="job_manager.queue">
       <i class="hourglass start icon"></i>
       {{job_manager.queue.thread.pending.length + job_manager.queue.process.pending.length }}
-    </div>
+    </button>
     <!-- memory -->
-    <div class="ui small grey label"
+    <button class="ui compact labeled icon button tiny"
       data-tooltip="Amount of memory hub is currently using"
-      data-position="bottom center"
+      data-position="top right"
       v-if="job_manager.queue">
       <i class="right microchip icon"></i>
       {{ job_manager.memory | pretty_size}}
-    </div>
+    </button>
   </div>
 </template>
 
@@ -65,14 +65,14 @@ export default {
     $('.processes.button').popup({
         popup: $('.processes.popup'),
         on: 'click' ,
-        lastResort: 'bottom right',
+        lastResort: 'top right',
         onVisible: () => {this.onJobsOpened(true)},
         onHide: () => {this.onJobsOpened(false)},
     });
     $('.threads.button').popup({
         popup: $('.threads.popup'),
         on: 'click' ,
-        lastResort: 'bottom right',
+        lastResort: 'top right',
         onVisible: () => {this.onJobsOpened(true)},
         onHide: () => {this.onJobsOpened(false)},
     });

--- a/biothings/hub/webapp/src/LogViewer.vue
+++ b/biothings/hub/webapp/src/LogViewer.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="logviewer" class="ui inverted segment" style="overflow: auto; width: 45vw; max-height: 33vh; max-width: 45vw;">
+    <div id="logviewer" class="ui inverted segment" style="overflow-y: auto; width: 85vw; max-height: 73vh; max-width: 85vw;">
         <table class="ui single line super compact inverted table" v-if="records.length">
             <tbody>
                 <log-record v-for="record of records" v-bind:record="record"></log-record>


### PR DESCRIPTION
Moves indicators from top menu bar to bottom. Makes the log window larger when expanded. Fixes #91 