### PR TITLE
Update hub and web requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,11 @@ if commit_hash or num_commits:
 install_requires = [
     'requests>=2.21.0',
     'tornado==5.1.1',
-    'gitpython>=3.1.0'
+    'gitpython>=3.1.0',
     'elasticsearch>=6, <8',
     'elasticsearch-dsl>=6, <8',
     'elasticsearch-async>=6.2.0'
+    'aiohttp==3.6.2'
 ]
 
 # extra requirements for biothings.web

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ web_extra_requires = [
 hub_requires = [
     'beautifulsoup4',   # used in dumper.GoogleDriveDumper
     'aiocron',          # setup scheduled jobs
+    'aiohttp==3.6.2',
     'asyncssh==1.7.1',  # needs libffi-dev installed (apt-get)
     'pymongo',
     'psutil',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     'elasticsearch>=6, <8',
     'elasticsearch-dsl>=6, <8',
     'elasticsearch-async>=6.2.0'
-    'aiohttp==3.6.2'
+    'aiohttp==3.6.2'    # for compatibility with elasticsearch-async==6.x
 ]
 
 # extra requirements for biothings.web
@@ -58,7 +58,7 @@ web_extra_requires = [
 hub_requires = [
     'beautifulsoup4',   # used in dumper.GoogleDriveDumper
     'aiocron',          # setup scheduled jobs
-    'aiohttp==3.6.2',
+    'aiohttp==3.6.2',   # for compatibility with elasticsearch-async==6.x
     'asyncssh==1.7.1',  # needs libffi-dev installed (apt-get)
     'pymongo',
     'psutil',


### PR DESCRIPTION
Freezes aiohttp to version 3.6.2, because version 3.7 is not compatible.