### PR TITLE
add check to array field causing issues before call

### DIFF
--- a/biothings/hub/webapp/src/DataSourceGrid.vue
+++ b/biothings/hub/webapp/src/DataSourceGrid.vue
@@ -109,7 +109,7 @@ export default {
             .then(response => {
                 function displayable(src) {
                     // if base is an autoupdate dumper, it means it's a "internal" datasource used to managed data releases
-                    if(src.download && src.download.dumper) {
+                    if(src.download && src.download.dumper && src.download.dumper.bases) {
                         return !src.download.dumper.bases.includes("biothings.hub.autoupdate.dumper.BiothingsDumper");
                     }
                     return true;


### PR DESCRIPTION
Since 'bases' is not guaranteed to be present best to add another condition in case any condition pair short circuits.  "includes" is an array prototype method and can't be called if undefined.  Program assumes it exists, this will add a check prior to call. 