### PR TITLE
update dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,13 @@ install_requires = [
     'elasticsearch-dsl>=6, <8',
     'elasticsearch-async>=6.2.0',
     'singledispatchmethod; python_version < "3.8.0"',
-    'aiohttp==3.6.2'    # for compatibility with elasticsearch-async==6.x
+    'aiohttp==3.6.2',    # for compatibility with elasticsearch-async==6.x
+    'PyYAML>=5.1',
 ]
 
 # extra requirements for biothings.web
 web_extra_requires = [
     'msgpack>=0.6.1',   # support format=msgpack
-    'PyYAML>=5.1',      # support format=yaml
 ]
 
 # extra requirements to run biothings.hub


### PR DESCRIPTION
moved PyYAML to the minimal reqs.
commit 2cce37656b40d1649871c2f5ec145873ce970d9b introduced `yaml` as a dependency that is no longer optional