### PR TITLE
New Unique user ID for GA

### DIFF
--- a/biothings/utils/web/analytics.py
+++ b/biothings/utils/web/analytics.py
@@ -77,7 +77,7 @@ class ExpiringDict:
         return len(self.od)
 
 
-exp_dict_uid = ExpiringDict(max_size=1000, ttl=3600)
+exp_dict_uid = ExpiringDict(max_size=0, ttl=0)
 
 
 def generate_unique_id(remote_ip: str, user_agent: str,
@@ -138,7 +138,7 @@ class GAMixIn:
             remote_ip = _req.headers.get("X-Real-Ip", _req.headers.get("X-Forwarded-For", _req.remote_ip))
             user_agent = _req.headers.get("User-Agent", "")
             host = _req.headers.get("Host", "N/A")
-            this_user = generate_unique_id(remote_ip, user_agent)
+            this_user = generate_unique_id(remote_ip, user_agent, tm=0)
             user_agent = _q(user_agent)
             # compile measurement protocol string for google
             # first do the pageview hit type

--- a/biothings/utils/web/analytics.py
+++ b/biothings/utils/web/analytics.py
@@ -18,13 +18,23 @@ class ExpiringDict:
     # cleanup on contain/get, does not clean on set
 
     def __init__(self, max_size: int = 1000, ttl: int = 3600):
+        """
+        Initialize a self expiring Dictionary
+
+        Configure a maximum allowed size and a time to live on items.
+        When an item is accessed, the TTL is reset. Removes exired items
+        on access (but not on set)
+        Args:
+            max_size: Maximum number of items that can be stored
+            ttl: time to live for items, in seconds
+        """
         self.od = OrderedDict()  # {key: (v, t)} eldest in the front
         self.max_size = max_size
         self.ttl = ttl
 
     def _cleanup(self, stop_key):
         while True:
-            k, v = self.od.popitem(last=False)
+            k, _ = self.od.popitem(last=False)
             if k == stop_key:
                 return
 
@@ -63,13 +73,20 @@ exp_dict_uid = ExpiringDict(max_size=1000, ttl=3600)
 
 def generate_unique_id(remote_ip: str, user_agent: str,
                        tm: Optional[int] = None):
-    """Generates a unique user ID
+    """
+    Generates a unique user ID
 
     Using the remote IP and client user agent, to produce a somewhat
     unique identifier for users. A UUID version 4 conforming to RFC 4122
     is produced which is generally acceptable. It is not entirely random,
     but looks random enough to the outside. Using a hash func. the user
     info is completely anonymized.
+
+    Args:
+        remote_ip: Client IP address, IPv4 or IPv6
+        user_agent: User agent string of the client
+        tm: Optional timestamp, as the generation is time dependent, setting
+            this will make it as if the generation was done at the given time.
 
     """
     global exp_dict_uid

--- a/biothings/utils/web/analytics.py
+++ b/biothings/utils/web/analytics.py
@@ -64,8 +64,17 @@ class ExpiringDict:
             if key in self:
                 pass
             else:
-                self.od.popitem()
-        self.od[key] = [value, time.time()]
+                try:
+                    self.od.popitem()
+                except KeyError:
+                    pass
+        if self.max_size > 0:
+            self.od[key] = [value, time.time()]
+        else:
+            pass  # just fail silently
+
+    def __len__(self):
+        return len(self.od)
 
 
 exp_dict_uid = ExpiringDict(max_size=1000, ttl=3600)

--- a/biothings/utils/web/analytics.py
+++ b/biothings/utils/web/analytics.py
@@ -73,8 +73,7 @@ exp_dict_uid = ExpiringDict(max_size=1000, ttl=3600)
 
 def generate_unique_id(remote_ip: str, user_agent: str,
                        tm: Optional[int] = None):
-    """
-    Generates a unique user ID
+    """Generates a unique user ID
 
     Using the remote IP and client user agent, to produce a somewhat
     unique identifier for users. A UUID version 4 conforming to RFC 4122

--- a/tests/utils/test_expiring_dict.py
+++ b/tests/utils/test_expiring_dict.py
@@ -1,0 +1,65 @@
+import pytest
+import time
+from biothings.utils.web.analytics import ExpiringDict
+
+
+class TestExpiringDict:
+    def test_init(self):
+        d = ExpiringDict()
+
+    def test_set_get(self):
+        d = ExpiringDict()
+        d['k'] = 'v'
+        assert d['k'] == 'v'
+
+    def test_contains_item(self):
+        d = ExpiringDict()
+        d['k'] = 'v'
+        assert 'k' in d
+
+    def test_not_contain(self):
+        d = ExpiringDict()
+        assert 'k' not in d
+
+    def test_expired_item(self):
+        d = ExpiringDict(ttl=0)
+        d['k'] = 'v'
+        with pytest.raises(KeyError):
+            assert d['k'] == 'v'
+
+    def test_item_expire_not_contain(self):
+        d = ExpiringDict(ttl=0)
+        d['k'] = 'v'
+        assert 'k' not in d
+
+    def test_get_refresh_item(self):
+        d = ExpiringDict(ttl=2)
+        d['k1'] = 'v1'
+        d['k2'] = 'v2'
+        time.sleep(1)
+        t = d['k2']
+        time.sleep(1)
+        assert 'k1' not in d
+        assert 'k2' in d
+
+
+    def test_auto_clean_old_item(self):
+        d = ExpiringDict(ttl=1)
+        d['k1'] = 'v'
+        d['k2'] = 'v'
+        time.sleep(1)
+        assert 'k2' not in d
+        assert 'k1' not in d.od  # autocleaned
+
+    def test_max_size(self):
+        d = ExpiringDict(max_size=1)
+        d['k1'] = 'v1'
+        d['k2'] = 'v2'
+        assert len(d.od) <= 1
+
+    def test_max_size_same_key(self):
+        d = ExpiringDict(max_size=1)
+        d['k1'] = 'v1'
+        d['k1'] = 'v2'
+        assert len(d.od) <= 1
+        assert d['k1'] == 'v2'

--- a/tests/utils/test_expiring_dict.py
+++ b/tests/utils/test_expiring_dict.py
@@ -57,6 +57,12 @@ class TestExpiringDict:
         d['k2'] = 'v2'
         assert len(d.od) <= 1
 
+    def test_zero_size(self):
+        d = ExpiringDict(max_size=0)
+        d['k1'] = 'v1'
+        d['k2'] = 'v2'
+        assert len(d) == 0
+
     def test_max_size_same_key(self):
         d = ExpiringDict(max_size=1)
         d['k1'] = 'v1'


### PR DESCRIPTION
- new method of generation, based on user IP, UA, and time, different processes usually can generate the same ID for the same user w/o prior communication with each other
- implement self expiring dict to cache results so repeated access in a time period is recogized as the same user
- added tests for exiring dict