### PR TITLE
Ensure source dump/upload successful before notifying via whatsnew

### DIFF
--- a/biothings/hub/databuild/builder.py
+++ b/biothings/hub/databuild/builder.py
@@ -1420,7 +1420,7 @@ class BuilderManager(BaseManager):
                             if not srcd['download']['status'] == "success":
                                 srcd = None
                         if srcd and srcd.get('upload'):
-                            for sub_name, sub in srcd['upload']['jobs'].items():
+                            for sub in srcd['upload']['jobs'].values():
                                 if not sub['status'] == "success":
                                     srcd = None
                                     break


### PR DESCRIPTION
Check dump/upload jobs status values, if not "success", it will unset the document, so that `whatsnewcomparedto` does not return the source as new. Fixes Issue #123 