### PR TITLE
Add default handlers for orjson

### DIFF
--- a/biothings/hub/api/handlers/base.py
+++ b/biothings/hub/api/handlers/base.py
@@ -30,7 +30,7 @@ class DefaultHandler(RequestHandler):
             return f"ConfigurationDefault: default: {obj.default}, desc: {obj.desc}"
 
         def configuration_value_handler(obj: ConfigurationValue):
-            return f"ConfigurationValue: FIXME!!"
+            return f"ConfigurationValue: {str(obj)}"
 
         handlers = {
             'biothings.ConfigurationDefault': configuration_default_handler,


### PR DESCRIPTION
Implemented as temporary fix for endpoints that emit `ConfigurationValue` and `ConfigurationDefault` (`/config`, namely).

Resolves Issue #137 in the short term.