### PR TITLE
Properly prevent depending on pyinotify

### DIFF
--- a/biothings/utils/hub.py
+++ b/biothings/utils/hub.py
@@ -694,91 +694,97 @@ class BaseHubReloader(object):
         raise NotImplementedError("Implement me in a sub-class")
 
 
-class PyInotifyHubReloader(BaseHubReloader):
-    """Based on pyinotify events"""
-
-    # inner class to hide pyinotify in case not available
+try:
     import pyinotify
-    class ReloadListener(pyinotify.ProcessEvent):
-    
-        def my_init(self, watcher_manager, reload_func):
+
+    class PyInotifyHubReloader(BaseHubReloader):
+        """Based on pyinotify events"""
+
+        # inner class to hide pyinotify in case not available
+        class ReloadListener(pyinotify.ProcessEvent):
+
+            def my_init(self, watcher_manager, reload_func):
+                self.reload_func = reload_func
+                self.watcher_manager = watcher_manager
+
+            def process_default(self, event):
+                pyinotify = sys.modules["pyinotify"]
+                if exclude_from_reloader(event.pathname):
+                    return
+                if event.dir:
+                    if event.mask & pyinotify.IN_CREATE:
+                        # add to watcher. no need to check if already watched, manager knows
+                        # how to deal with that
+                        logging.info("Add '%s' to watcher", event.pathname)
+                        self.watcher_manager.add_watch(event.pathname, self.notifier.mask, rec=1)
+                    elif event.mask & pyinotify.IN_DELETE:
+                        logging.info("Remove '%s' from watcher", event.pathname)
+                        # watcher knows when directory is deleted (file descriptor become invalid),
+                        # so no need to do it manually
+                logging.error("Need to reload manager because of %s", event)
+                self.reload_func()
+
+        def __init__(self, paths, reload_func, wait=5, mask=None):
+            pyinotify = sys.modules["pyinotify"] # get it from sys.modules or we'd need another "import"
+                                                 # just sure why...
+            if isinstance(paths, str):
+                paths = [paths]
+            paths = set(paths)  # get rid of duplicated, just in case
+            self.mask = mask or pyinotify.IN_CREATE|pyinotify.IN_DELETE|pyinotify.IN_CLOSE_WRITE
             self.reload_func = reload_func
-            self.watcher_manager = watcher_manager
-    
-        def process_default(self, event):
-            pyinotify = sys.modules["pyinotify"]
-            if exclude_from_reloader(event.pathname):
-                return
-            if event.dir:
-                if event.mask & pyinotify.IN_CREATE:
-                    # add to watcher. no need to check if already watched, manager knows
-                    # how to deal with that
-                    logging.info("Add '%s' to watcher", event.pathname)
-                    self.watcher_manager.add_watch(event.pathname, self.notifier.mask, rec=1)
-                elif event.mask & pyinotify.IN_DELETE:
-                    logging.info("Remove '%s' from watcher", event.pathname)
-                    # watcher knows when directory is deleted (file descriptor become invalid),
-                    # so no need to do it manually
-            logging.error("Need to reload manager because of %s", event)
-            self.reload_func()
-    
+            # only listen to these events. Note: directory detection is done via a flag so
+            # no need to use IS_DIR
+            self.watcher_manager = pyinotify.WatchManager(exclude_filter=exclude_from_reloader)
+            self.paths = []  # cleaned
+            for path in paths:
+                if not os.path.isabs(path):
+                    path = os.path.abspath(path)
+                self.paths.append(path)
+                self.watcher_manager.add_watch(path, self.mask, rec=True, exclude_filter=exclude_from_reloader)   # recursive
 
-    def __init__(self, paths, reload_func, wait=5, mask=None):
-        pyinotify = sys.modules["pyinotify"] # get it from sys.modules or we'd need another "import"
-                                             # just sure why...
-        if isinstance(paths, str):
-            paths = [paths]
-        paths = set(paths)  # get rid of duplicated, just in case
-        self.mask = mask or pyinotify.IN_CREATE|pyinotify.IN_DELETE|pyinotify.IN_CLOSE_WRITE
-        self.reload_func = reload_func
-        # only listen to these events. Note: directory detection is done via a flag so
-        # no need to use IS_DIR
-        self.watcher_manager = pyinotify.WatchManager(exclude_filter=exclude_from_reloader)
-        self.paths = []  # cleaned
-        for path in paths:
-            if not os.path.isabs(path):
-                path = os.path.abspath(path)
-            self.paths.append(path)
-            self.watcher_manager.add_watch(path, self.mask, rec=True, exclude_filter=exclude_from_reloader)   # recursive
+            self.listener = self.__class__.ReloadListener(
+                    watcher_manager=self.watcher_manager,
+                    reload_func=self.reload_func)
+            self.notifier = pyinotify.Notifier(
+                    self.watcher_manager,
+                    default_proc_fun=self.listener
+                    )
+            # propagate notifier so notifer itself can be reloaded (when new directory/source)
+            self.listener.notifier = self
+            self.wait = wait
+            self.do_monitor = False
 
-        self.listener = self.__class__.ReloadListener(
-                watcher_manager=self.watcher_manager,
-                reload_func=self.reload_func)
-        self.notifier = pyinotify.Notifier(
-                self.watcher_manager,
-                default_proc_fun=self.listener
+        def monitor(self):
+
+            @asyncio.coroutine
+            def do():
+                logging.info(
+                    "Monitoring source code in, %s:\n%s",
+                    repr(self.paths),
+                    pformat(self.watched_files())
                 )
-        # propagate notifier so notifer itself can be reloaded (when new directory/source)
-        self.listener.notifier = self
-        self.wait = wait
-        self.do_monitor = False
+                while self.do_monitor:
+                    try:
+                        yield from asyncio.sleep(self.wait)
+                        # this reads events from OS
+                        if self.notifier.check_events(0.1):
+                            self.notifier.read_events()
+                        # Listener gets called there if event avail
+                        self.notifier.process_events()
+                    except KeyboardInterrupt:
+                        logging.warning("Stop monitoring code")
+                        break
 
-    def monitor(self):
+            self.do_monitor = True
+            return asyncio.ensure_future(do())
 
-        @asyncio.coroutine
-        def do():
-            logging.info(
-                "Monitoring source code in, %s:\n%s",
-                repr(self.paths),
-                pformat(self.watched_files())
-            )
-            while self.do_monitor:
-                try:
-                    yield from asyncio.sleep(self.wait)
-                    # this reads events from OS
-                    if self.notifier.check_events(0.1):
-                        self.notifier.read_events()
-                    # Listener gets called there if event avail
-                    self.notifier.process_events()
-                except KeyboardInterrupt:
-                    logging.warning("Stop monitoring code")
-                    break
-
-        self.do_monitor = True
-        return asyncio.ensure_future(do())
-
-    def watched_files(self):
-        return [v.path for v in self.watcher_manager.watches.values()]
+        def watched_files(self):
+            return [v.path for v in self.watcher_manager.watches.values()]
+except ImportError:
+    class PyInotifyHubReloader:
+        def __new__(cls, *args, **kwargs):
+            raise RuntimeError("Can't create PyInotifyHubReloader instance"
+                               "without inotify")
 
 
 class TornadoAutoReloadHubReloader(BaseHubReloader):


### PR DESCRIPTION
The original code intends to hide the functionality, but in practice it does not work (explained later)

This change makes sure that hub can run when pyinotify is not installed or available (e.g. on macOS, various BSDs)

The code has been somewhat tested:
1. It does function like before on Linux with inotify feature and the pyinotify package installed (reloads on change detected)
2. It does function on other OS w/o inotify, this case the Tornado based reloader is used. Tested on macOS and works, should also work on BSD and others.
3. It does function on Linux w/o inotify (docker emulated x86_64 on M1 Macs), remove the pyinotify package and it should work
What's not tested:
1. Trying to create an inotify based reloader should raise an exception when pyinotify package is not installed. Didn't test because it's not important.

Actual test coverage is not collected due to the way hub restarts itself (kills itself on restart).


Explanation:

The original code wraps `import pyinotify` in a `PyInotifyHubReloader` class, and then only instantiates the class in `get_hub_reloader` when `pyinotify` is successfully imported, hoping that this would prevent the import statement in the class body from executing.

However this is futile due to the way classes are defined: the body is executed in its own scope, and the resulting scope creates the class (see Python `type` documentation for more details). This means that things like imports, variable and method declarations (but not the method body) are executed during class declaration. Therefore the import is never wrapped, it's always run when importing `biothings.utils.hub`, raising `ImportError` when `pyinotify` does not exist.

This change wraps the class declaration in a try-except statement so that it can be avoided. This is a solution that works for now, and perhaps needs more fine-tuning in the future -- the pyinofity package hasn't been updated in over 5 years anyways and if we continue to use inotify it's best we rewrite it in the future.