### PR TITLE
Fix gitdumper default branch

### DIFF
--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -1078,8 +1078,8 @@ class GitDumper(BaseDumper):
         cmd = ['git', 'ls-remote', '--symref', self.GIT_REPO_URL, 'HEAD']
         try:
             # set locale to C so the output may have more reliable format
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, timeout=5,
-                                    check=True, env={'LC_ALL': 'C'})
+            result = subprocess.run(cmd, stdout=subprocess.PIPE,  # noseq
+                                    timeout=5, check=True, env={'LC_ALL': 'C'})
             r = re.compile(rb'^ref:\s+refs\/heads\/(.*)\s+HEAD$',
                            flags=re.MULTILINE)
             m = r.match(result.stdout)
@@ -1107,6 +1107,7 @@ class GitDumper(BaseDumper):
         return ret
 
     def _get_default_branch(self) -> Union[bytes, str]:
+        # pylint: disable=bare-except
         # TODO: check TODO in _pull regarding original exclusive use of
         #  class variable
         # Case 1, default is explicitly set
@@ -1121,7 +1122,7 @@ class GitDumper(BaseDumper):
             branches = self._get_remote_branches()
             if b'main' in branches and b'master' not in branches:
                 return 'main'
-        except:
+        except:  # noseq
             # fallback anything goes wrong
             pass
         # Case 4, use 'master' for compatibility reasons

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -1122,7 +1122,7 @@ class GitDumper(BaseDumper):
             branches = self._get_remote_branches()
             if b'main' in branches and b'master' not in branches:
                 return 'main'
-        except:  # nosec
+        except:  # nosec  # noqa
             # fallback anything goes wrong
             pass
         # Case 4, use 'master' for compatibility reasons

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -1,26 +1,26 @@
-import re
-import time
+import asyncio
+import cgi
+import inspect
 import os
 import pprint
-import cgi
-from datetime import datetime
-import asyncio
-from functools import partial
-import inspect
+import re
 import subprocess
+import time
+from datetime import datetime
+from functools import partial
+from typing import Optional, Union, List
 
-from biothings.utils.hub_db import get_src_dump
-from biothings.utils.common import timesofar, rmdashfr
-from biothings.utils.loggers import get_logger
-from biothings.hub import DUMPER_CATEGORY, UPLOADER_CATEGORY
 from biothings import config as btconfig
-from biothings.utils.manager import BaseSourceManager, ResourceError
+from biothings.hub import DUMPER_CATEGORY, UPLOADER_CATEGORY
 from biothings.hub.dataload.uploader import set_pending_to_upload
+from biothings.utils.common import timesofar, rmdashfr
+from biothings.utils.hub_db import get_src_dump
+from biothings.utils.loggers import get_logger
+from biothings.utils.manager import BaseSourceManager, ResourceError
 
 logging = btconfig.logger
 
 
-from typing import Optional, Union, List
 
 
 class DumperException(Exception):

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -1083,7 +1083,7 @@ class GitDumper(BaseDumper):
             result = subprocess.run(cmd, stdout=subprocess.PIPE, timeout=5,
                                     env={'LC_ALL': 'C'})
             if result.returncode == 0:
-                r = re.compile(rb'^ref:\s+refs/heads/(.*)\s+HEAD$',
+                r = re.compile(rb'^ref:\s+refs\/heads\/(.*)\s+HEAD$',
                                flags=re.MULTILINE)
                 m = r.match(result.stdout)
                 if m is not None:
@@ -1100,11 +1100,10 @@ class GitDumper(BaseDumper):
             result = subprocess.run(cmd, stdout=subprocess.PIPE, timeout=5,
                                     env={'LC_ALL': 'C'})
             if result.returncode == 0:
-                r = re.compile(rb'^ref:\s+refs/heads/(.*)$',
+                r = re.compile(rb'^[0-9a-f]{40}\s+refs\/heads\/(.*)$',
                                flags=re.MULTILINE)
-                m = r.match(result.stdout)
-                if m is not None:
-                    ret.append(m[1])
+                for m in re.findall(r, result.stdout):
+                    ret.append(m)
         except TimeoutError:
             pass
         return ret

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -1094,8 +1094,8 @@ class GitDumper(BaseDumper):
         ret = []
         try:
             # set locale to C so the output may have more reliable format
-            result = subprocess.run(cmd, stdout=subprocess.PIPE, timeout=5,
-                                    check=True, env={'LC_ALL': 'C'})  # nosec
+            result = subprocess.run(cmd, stdout=subprocess.PIPE,  # nosec
+                                    timeout=5, check=True, env={'LC_ALL': 'C'})
             # user controls the URL anyways, and we don't use a shell
             # so it is safe
             r = re.compile(rb'^[0-9a-f]{40}\s+refs\/heads\/(.*)$',

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -1078,7 +1078,7 @@ class GitDumper(BaseDumper):
         cmd = ['git', 'ls-remote', '--symref', self.GIT_REPO_URL, 'HEAD']
         try:
             # set locale to C so the output may have more reliable format
-            result = subprocess.run(cmd, stdout=subprocess.PIPE,  # noseq
+            result = subprocess.run(cmd, stdout=subprocess.PIPE,  # nosec
                                     timeout=5, check=True, env={'LC_ALL': 'C'})
             r = re.compile(rb'^ref:\s+refs\/heads\/(.*)\s+HEAD$',
                            flags=re.MULTILINE)
@@ -1095,7 +1095,7 @@ class GitDumper(BaseDumper):
         try:
             # set locale to C so the output may have more reliable format
             result = subprocess.run(cmd, stdout=subprocess.PIPE, timeout=5,
-                                    check=True, env={'LC_ALL': 'C'})  # noseq
+                                    check=True, env={'LC_ALL': 'C'})  # nosec
             # user controls the URL anyways, and we don't use a shell
             # so it is safe
             r = re.compile(rb'^[0-9a-f]{40}\s+refs\/heads\/(.*)$',
@@ -1122,7 +1122,7 @@ class GitDumper(BaseDumper):
             branches = self._get_remote_branches()
             if b'main' in branches and b'master' not in branches:
                 return 'main'
-        except:  # noseq
+        except:  # nosec
             # fallback anything goes wrong
             pass
         # Case 4, use 'master' for compatibility reasons

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -1098,7 +1098,9 @@ class GitDumper(BaseDumper):
         try:
             # set locale to C so the output may have more reliable format
             result = subprocess.run(cmd, stdout=subprocess.PIPE, timeout=5,
-                                    env={'LC_ALL': 'C'})
+                                    env={'LC_ALL': 'C'})  # noseq
+            # user controls the URL anyways, and we don't use a shell
+            # so it is safe
             if result.returncode == 0:
                 r = re.compile(rb'^[0-9a-f]{40}\s+refs\/heads\/(.*)$',
                                flags=re.MULTILINE)
@@ -1123,7 +1125,7 @@ class GitDumper(BaseDumper):
             branches = self._get_remote_branches()
             if b'main' in branches and b'master' not in branches:
                 return 'main'
-        except:  # noqa: E722
+        except:  # noseq
             # fallback anything goes wrong
             pass
         # Case 4, use 'master' for compatibility reasons


### PR DESCRIPTION
Manually tested and seems to work fine. Instead of just using 'main' as the default branch, `GitDumper` will actually try to see what the default branch is on the remote repo.

I did not test the case where `DEFAULT_BRANCH` is explicitly set (does anything use this?)

Also, according to my understanding of the git-scm docs, remote could have no default branch (no HEAD). However I cannot find a way to create that kind of test environment, and most likely the fallback solutions will work fine (return `None` and guess based on heuristics), and if it actually affects anyone it shouldn't be hard to fix.


Let me know the part about `DEFAULT_BRANCH` because I changed the default to `None` so we would know that it's explicitly set to some value, I don't think this will break anything because I don't see read anywhere, except for in the hub autoupgrader, where it is explicitly set to the current branch.

If there are no objections, I will merge this PR after the end of the day.