### PR TITLE
Add delete file functionality to BaseDumper

### DIFF
--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -219,6 +219,7 @@ class BaseDumper(object):
             else:
                 raise RuntimeError(f"{rel_file_name} ({delete_path}) is not "
                                    "a regular file or directory, cannot delete")
+        self.to_delete = []  # reset the list in case
 
     def post_dump(self, *args, **kwargs):
         """


### PR DESCRIPTION
Introduced a instance variable `to_delete` and a method `post_dump_delete_files` to `BaseDumper`.

`to_delete` includes a list of relative path of files and directories that need to be deleted. Descendants of this class can populate the list by appending to it.

`post_dump_delete_files` should be invoked in `post_dump` method to delete the files synchronously, while `post_dump` is run in a separate thread by the `dump` method. Descendants of `BaseDumper` should call this method explicitly.

`post_dump_delete_files` does not delete files recursively and only supports deleting regular files and directories. And, it specifically avoids using `shutil.rmtree` so that deletions can be logged and minimizes the risk of accidentally deleting files. It is also hardened against directory traversal attacks.