### PR TITLE
Add Bundled, Configurable Parsers

### DIFF
--- a/biothings/hub/dataplugin/assistant.py
+++ b/biothings/hub/dataplugin/assistant.py
@@ -266,7 +266,16 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 mod, func = uploader_section.get("parser").split(":")
                 confdict["PARSER_MOD"] = mod
                 confdict["PARSER_FUNC"] = func
-                confdict["PARSER_FACTORY_CODE"] = ''
+                if uploader_section['parser'].get('parser_kwargs'):
+                    confdict["PARSER_FACTORY_CODE"] = textwrap.dedent(f'''
+                        # Setup parser to parser factory
+                        from {mod} import {func} as parser_factory
+                        
+                        parser_kwargs = dict()
+                        parser_func = parser_factory(**parser_kwargs)
+                    ''')
+                else:
+                    confdict["PARSER_FACTORY_CODE"] = ''
             except ValueError:
                 raise AssistantException("'parser' must be defined as 'module:parser_func' but got: '%s'" %
                                          uploader_section["parser"])

--- a/biothings/hub/dataplugin/assistant.py
+++ b/biothings/hub/dataplugin/assistant.py
@@ -133,6 +133,17 @@ class ManifestBasedPluginLoader(BasePluginLoader):
             self.invalidate_plugin("Missing plugin folder '%s'" % df)
 
     def get_code_for_mod_name(self, mod_name):
+        """
+        Returns string literal and name of function, given a path
+
+        Args:
+            mod_name: string with module name and function name, separated by colon
+
+        Returns:
+            Tuple[str, str]: containing
+                - indented string literal for the function specified
+                - name of the function
+        """
         try:
             mod, funcname = map(str.strip, mod_name.split(":"))
         except ValueError as e:

--- a/biothings/hub/dataplugin/assistant.py
+++ b/biothings/hub/dataplugin/assistant.py
@@ -266,6 +266,7 @@ class ManifestBasedPluginLoader(BasePluginLoader):
                 mod, func = uploader_section.get("parser").split(":")
                 confdict["PARSER_MOD"] = mod
                 confdict["PARSER_FUNC"] = func
+                confdict["PARSER_FACTORY_CODE"] = ''
             except ValueError:
                 raise AssistantException("'parser' must be defined as 'module:parser_func' but got: '%s'" %
                                          uploader_section["parser"])

--- a/biothings/hub/dataplugin/uploader.py.tpl
+++ b/biothings/hub/dataplugin/uploader.py.tpl
@@ -5,11 +5,6 @@ biothings.config_for_app(config)
 
 import biothings.hub.dataload.uploader
 
-# when code is exported, import becomes relative
-try:
-    from $SRC_NAME.$PARSER_MOD import $PARSER_FUNC as parser_func
-except ImportError:
-    from .$PARSER_MOD import $PARSER_FUNC as parser_func
 
 $PARSER_FACTORY_CODE
 

--- a/biothings/hub/dataplugin/uploader.py.tpl
+++ b/biothings/hub/dataplugin/uploader.py.tpl
@@ -11,6 +11,8 @@ try:
 except ImportError:
     from .$PARSER_MOD import $PARSER_FUNC as parser_func
 
+$PARSER_FACTORY_CODE
+
 $IMPORT_IDCONVERTER_FUNC
 
 class $UPLOADER_NAME($BASE_CLASSES):

--- a/biothings/utils/parsers.py
+++ b/biothings/utils/parsers.py
@@ -1,0 +1,70 @@
+import pathlib
+from typing import Callable, Generator, Iterable, Optional
+
+import orjson
+
+
+def ndjson_parser(patterns: Optional[Iterable[str]] = None,) \
+        -> Callable[[str], Generator[dict, None, None]]:
+    """
+    Create NDJSON Parser given filename patterns
+
+    For use with manifest.json based plugins.
+    Caveat: Only handles valid NDJSON (no extra newlines, UTF8, etc.)
+
+    Args:
+        patterns: glob-compatible patterns for filenames, like *.ndjson, data*.ndjson
+
+    Returns:
+        parser_func: Generator that takes in a data_folder and returns documents from
+            NDJSON files that matches the filename patterns
+    """
+    if patterns is None:
+        raise TypeError("Must provide keyword argument patterns to"
+                        "match files for NDJSON Parser")
+
+    def ndjson_parser_func(data_folder):
+        work_dir = pathlib.Path(data_folder)
+        for pattern in patterns:
+            for filename in work_dir.glob(pattern):
+                with open(filename, 'rb') as f:
+                    for line in f:
+                        doc = orjson.loads(line)
+                        yield doc
+
+    return ndjson_parser_func
+
+
+def json_array_parser(patterns: Optional[Iterable[str]] = None) \
+        -> Callable[[str], Generator[dict, None, None]]:
+    """
+       Create JSON Array Parser given filename patterns
+
+       For use with manifest.json based plugins. The data comes in a JSON that is
+       an JSON array, containing multiple documents.
+
+       Args:
+           patterns: glob-compatible patterns for filenames, like *.json, data*.json
+
+       Returns:
+           parser_func
+    """
+    if patterns is None:
+        raise TypeError("Must provide keyword argument patterns to"
+                        "match files for JSON Array Parser")
+
+    def json_array_parser(data_folder):
+        work_dir = pathlib.Path(data_folder)
+        for pattern in patterns:
+            for filename in work_dir.glob(pattern):
+                with open(filename, 'r') as f:
+                    data = orjson.loads(f.read())
+                    try:
+                        iterator = iter(data)
+                    except TypeError:
+                        raise RuntimeError(f"{filename} does not contain a valid"
+                                           "JSON Array")
+                    for doc in iterator:
+                        yield doc
+
+    return json_array_parser


### PR DESCRIPTION
To use them in manifest based plugins, create the manifest.json file to contain something like this:

```json
{
"uploader" : {
        "parser" : "biothings.util.parsers:ndjson_parser",
        "parser_kwargs": {
            "patterns": ["data.ndjson", "data_extra_*.ndjson"]
        }
    }
}