### PR TITLE
Remove weak etag prefix in version strings

### DIFF
--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -874,7 +874,8 @@ class LastModifiedHTTPDumper(HTTPDumper, LastModifiedBaseDumper):
                 self.release = remote_dt.strftime(
                     self.__class__.RELEASE_FORMAT)
             except KeyError:
-                self.release = res.headers[self.__class__.ETAG]
+                # Use entity tag (ETag) as version number. Remove weak ETag prefix.
+                self.release = res.headers[self.__class__.ETAG].lstrip("W/")
 
 
 class WgetDumper(BaseDumper):

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -875,6 +875,8 @@ class LastModifiedHTTPDumper(HTTPDumper, LastModifiedBaseDumper):
                     self.__class__.RELEASE_FORMAT)
             except KeyError:
                 # Use entity tag (ETag) as version number. Remove weak ETag prefix.
+                # Nginx marks an ETag as weak whenever a response body has been modified (including compression with gzip).
+                # See: https://stackoverflow.com/questions/55305687/how-to-address-weak-etags-conversion-by-nginx-on-gzip-compression
                 self.release = res.headers[self.__class__.ETAG].lstrip("W/")
 
 

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -877,7 +877,10 @@ class LastModifiedHTTPDumper(HTTPDumper, LastModifiedBaseDumper):
                 # Use entity tag (ETag) as version number. Remove weak ETag prefix.
                 # Nginx marks an ETag as weak whenever a response body has been modified (including compression with gzip).
                 # See: https://stackoverflow.com/questions/55305687/how-to-address-weak-etags-conversion-by-nginx-on-gzip-compression
-                self.release = res.headers[self.__class__.ETAG].lstrip("W/")
+                etag = res.headers[self.__class__.ETAG]
+                if etag.startswith("W/"):
+                    etag = etag[2:]
+                self.release = etag
 
 
 class WgetDumper(BaseDumper):


### PR DESCRIPTION
Removes the prepended "W/" from datasource version strings when they use weak ETags.