### PR TITLE
Fix to MyVariant Issue#103

### DIFF
--- a/biothings/hub/datarelease/publisher.py
+++ b/biothings/hub/datarelease/publisher.py
@@ -10,7 +10,7 @@ import asyncio
 from functools import partial
 import subprocess
 
-from releasenote import ReleaseNoteSrcBuildReader, ReleaseNoteSource
+from .releasenote import ReleaseNoteSrcBuildReader, ReleaseNoteSource
 
 from biothings.utils.mongo import get_previous_collection, get_target_db
 from biothings.utils.hub_db import get_src_build, get_source_fullname

--- a/biothings/hub/datarelease/publisher.py
+++ b/biothings/hub/datarelease/publisher.py
@@ -12,10 +12,9 @@ import subprocess
 
 from .releasenote import ReleaseNoteSrcBuildReader, ReleaseNoteSource
 
-from biothings.utils.mongo import get_previous_collection, get_target_db
-from biothings.utils.hub_db import get_src_build, get_source_fullname
+from biothings.utils.mongo import get_previous_collection
+from biothings.utils.hub_db import get_src_build
 import biothings.utils.aws as aws
-from biothings.utils.dataload import update_dict_recur
 from biothings.utils.loggers import get_logger
 from biothings.utils.manager import BaseManager, BaseStatusRegisterer
 from biothings.utils.backend import DocMongoBackend
@@ -240,9 +239,9 @@ class BasePublisher(BaseManager, BaseStatusRegisterer):
                         return archive_file
                     else:
                         # produce a json file with metadata about the splits
-                        jsonfile = "%s.json" % outfile
+                        jsonfile = "%s.json" % archive_file
                         json.dump({
-                            "filename": outfile,
+                            "filename": archive_file,
                             "parts": flist
                         }, open(jsonfile, "w"))
                         self.logger.info(

--- a/biothings/hub/datarelease/releasenote.py
+++ b/biothings/hub/datarelease/releasenote.py
@@ -12,6 +12,8 @@ locale.setlocale(locale.LC_ALL, '')
 
 
 class ReleaseNoteSrcBuildReader:
+    # TODO shall we use biothings.hub.dataindex.indexer._Build_doc here?
+
     def __init__(self, src_build_doc: dict):
         self.src_build_doc = src_build_doc
 

--- a/biothings/hub/datarelease/releasenote.py
+++ b/biothings/hub/datarelease/releasenote.py
@@ -1,43 +1,336 @@
+from __future__ import annotations  # for cyclic type hints
+
+from biothings.utils.hub_db import get_source_fullname
+from biothings.utils.dataload import update_dict_recur
+from biothings.utils.jsondiff import make as make_json_diff
+
 from dateutil.parser import parse as dtparse
+from datetime import datetime
 import locale
 
 locale.setlocale(locale.LC_ALL, '')
 
 
+class ReleaseNoteSrcBuildReader:
+    def __init__(self, src_build_doc: dict):
+        self.src_build_doc = src_build_doc
+
+        # If `self` is a "hot" src_build doc reader, it can refer to a "cold" reader to access the cold build info.
+        # This works like a two-node linked list.
+        self.cold_src_build_reader: ReleaseNoteSrcBuildReader = None
+
+    @property
+    def build_id(self) -> str:
+        return self.src_build_doc["_id"]
+
+    @property
+    def build_version(self) -> str:
+        return self.src_build_doc.get("_meta", {}).get("build_version")
+
+    @property
+    def cold_collection_name(self) -> str:
+        return self.src_build_doc.get("build_config", {}).get("cold_collection", None)
+
+    def has_cold_collection(self) -> bool:
+        return self.cold_collection_name is not None
+
+    def attach_cold_src_build_reader(self, other: ReleaseNoteSrcBuildReader):
+        """
+        Attach a cold src_build reader.
+
+        It's required that `self` is a hot src_builder reader and `other` is cold.
+        """
+        if not self.has_cold_collection():
+            raise ValueError(f"{self.build_id} is not a hot src_build doc, "
+                             f"thus not able to attach a cold reader of {other.build_id}.")
+
+        if other.has_cold_collection():
+            raise ValueError(f"{other.build_id} is a hot src_build doc, "
+                             f"thus not able to be attached to the reader of {self.build_id}")
+
+        # src_build `_id`s and collection names are interchangeable
+        # See https://github.com/biothings/biothings.api/blob/master/biothings/hub/databuild/builder.py#L311
+        if self.cold_collection_name != other.build_id:
+            raise ValueError(f"{self.build_id} has cold collection {self.cold_collection_name}, "
+                             f"while the reader to be attached is for {other.build_id}")
+
+        self.cold_src_build_reader = other
+
+    @property
+    def build_stats(self) -> dict:
+        meta = self.src_build_doc.get("_meta", {})
+        return meta.get("stats", {})
+
+    def _get_datasource_stats(self) -> dict:
+        return self.src_build_doc.get("merge_stats", {})
+
+    def _get_datasource_versions(self) -> dict:
+        meta = self.src_build_doc.get("_meta", {})
+
+        # previous version format
+        if "src_version" in meta:
+            return meta["src_version"]
+
+        # current version format
+        src = meta.get("src", {})
+        src_version = {src_name: src_info["version"] for src_name, src_info in src.items() if "version" in src_info}
+        return src_version
+
+    def _get_datasource_mapping(self) -> dict:
+        return self.src_build_doc.get("mapping", {})
+
+    @property
+    def datasource_stats(self) -> dict:
+        if not self.has_cold_collection():
+            return self._get_datasource_stats()
+
+        combined_stats = {
+            **self._get_datasource_stats(),
+            **self.cold_src_build_reader._get_datasource_stats()
+        }
+        return combined_stats
+
+    @property
+    def datasource_versions(self) -> dict:
+        if not self.has_cold_collection():
+            return self._get_datasource_versions()
+
+        combined_versions = {
+            **self._get_datasource_versions(),
+            **self.cold_src_build_reader._get_datasource_versions()
+        }
+        return combined_versions
+
+    @property
+    def datasource_mapping(self) -> dict:
+        if not self.has_cold_collection():
+            return self._get_datasource_mapping()
+
+        combined_mapping = {
+            **self._get_datasource_mapping(),
+            **self.cold_src_build_reader._get_datasource_mapping()
+        }
+        return combined_mapping
+
+
+class ReleaseNoteDatasourceInfoReader:
+    def __init__(self, src_build_reader: ReleaseNoteSrcBuildReader):
+        self.src_build_reader = src_build_reader
+
+    @property
+    def _transformed_datasource_stats(self) -> dict:
+        """
+        Receive a stat dictionary of <datasource_name>:<doc_count>, fetch the full datasource name, and
+        return a new stat dictionary.
+
+        If a full datasource name is two-tier (e.g. "gnomad.gnomad_exomes_hg19", as the full datasource name of
+        "gnomad_exomes_hg19"), the returned dictionary is formed as:
+
+            { <main_datasource_name> : { <sub_datasource_name> : { "_count" : <doc_count> } } }
+
+        e.g.
+
+            { "gnomad" : { "gnomad_exomes_hg19" : { "_count" : 12345678 } } }
+
+        If a full datasource name is one-tier:
+            CASE 1: the full datasource name is identical to the input datasource name,
+                e.g. "cosmic" is the full name of "cosmic";
+            CASE 2: the full datasource is None,
+                e.g. when the input datasource name is "observed" or "total" in MyVariant, or "total_*" in MyGene
+                In this case, the input datasource name is not a merge stat from a source but a custom field stat.
+
+        the returned stats dictionary has the following structure:
+
+            { <datasource_name> : { "_count" : <doc_count> } }
+
+        e.g.
+
+            { "cosmic" : { "_count" : 12345678 } }
+            { "total" : { "_count" : 12345678 } }
+        """
+        result = {}
+        for datasource_name, doc_count in self.src_build_reader.datasource_stats.items():
+            datasource_fullname = get_source_fullname(datasource_name)
+
+            if (datasource_fullname is None) or (datasource_fullname == datasource_name):
+                # one-tier fullname
+                result[datasource_name] = {"_count": doc_count}
+            else:
+                # two-tier fullname
+                main_name, sub_name = datasource_fullname.split(".")
+                result.setdefault(main_name, {})
+                result[main_name][sub_name] = {"_count": doc_count}
+
+        return result
+
+    @property
+    def _transformed_datasource_versions(self) -> dict:
+        """
+        For each datasource (e.g. clinvar, dbsnp) attached to the build, get its version number (e.g. "2022-01",
+        "155"). A dictionary of the following structure is returned:
+
+            { <datasource_name> : {"_version" : <datasource_version>} }
+        """
+        return dict((k, {"_version": v}) for k, v in self.src_build_reader.datasource_versions.items())
+
+    @property
+    def datasource_info(self):
+        datasource_versions = self._transformed_datasource_versions
+        datasource_stats = self._transformed_datasource_stats
+
+        datasource_info = update_dict_recur(datasource_versions, datasource_stats)
+        return datasource_info
+
+
+class ReleaseNoteSource:
+    def __init__(self,
+                 old_src_build_reader: ReleaseNoteSrcBuildReader,
+                 new_src_build_reader: ReleaseNoteSrcBuildReader,
+                 diff_stats_from_metadata_file: dict,
+                 addon_note: str):
+        self.old_src_build_reader = old_src_build_reader
+        self.new_src_build_reader = new_src_build_reader
+
+        self.old_datasource_info_reader = ReleaseNoteDatasourceInfoReader(self.old_src_build_reader)
+        self.new_datasource_info_reader = ReleaseNoteDatasourceInfoReader(self.new_src_build_reader)
+
+        self.diff_stats_from_metadata_file = diff_stats_from_metadata_file
+        self.addon_note = addon_note
+
+    @classmethod
+    def _make_stats_diff(cls, old: dict, new: dict):
+        result = {
+            "added": {},
+            "deleted": {},
+            "updated": {},
+        }
+
+        diff = make_json_diff(old, new)
+        for item in diff:
+            # get main source / main field
+            key = item["path"].strip("/").split("/")[0]
+            if item["op"] == "add":
+                result["added"][key] = new[key]
+            elif item["op"] == "remove":
+                result["deleted"][key] = old[key]
+            elif item["op"] == "replace":
+                result["updated"][key] = {"new": new[key], "old": old[key]}
+            else:
+                raise ValueError("Unknown operation '%s' while computing changes" % item["op"])
+
+        return result
+
+    @classmethod
+    def _make_mapping_diff(cls, old: dict, new: dict):
+        def mapping_path_to_field_name(path: str) -> str:
+            """
+            Convert a JSON-Pointer path in a mapping json to a field name.
+
+                E.g. path "/dbnsfp/properties/altai_neandertal" => field name "dbnsfp.altai_neandertal".
+
+            Note that "properties" should not be included as part of a field name.
+            The strategy here is iterate over the path components and remove any "properties" found at odd
+            indices (1, 3, 5...).
+            """
+            path_components = path.strip("/").split("/")
+            path_components = [path_components[i] for i in range(len(path_components))
+                               if (i % 2 == 0) or (i % 2 == 1 and path_components[i] != "properties")]
+            return ".".join(path_components)
+
+        fields = {}
+
+        diff = make_json_diff(old, new)
+        for item in diff:
+            if item["op"] in ("add", "remove", "replace"):
+                field_name = mapping_path_to_field_name(item["path"])
+                fields.setdefault(item["op"], []).append(field_name)
+            elif item["op"] == "move":
+                add_field_name = mapping_path_to_field_name(item["path"])
+                remove_field_name = mapping_path_to_field_name(item["from"])
+
+                fields.setdefault("add", []).append(add_field_name)
+                fields.setdefault("remove", []).append(remove_field_name)
+            else:
+                raise ValueError("Unknown operation '%s' while computing changes" % item["op"])
+
+        return fields
+
+    def diff_build_stats(self) -> dict:
+        old_stats = self.old_src_build_reader.build_stats
+        new_stats = self.new_src_build_reader.build_stats
+
+        return self._make_stats_diff(old_stats, new_stats)
+
+    def diff_datasource_info(self) -> dict:
+        old_info = self.old_datasource_info_reader.datasource_info
+        new_info = self.new_datasource_info_reader.datasource_info
+
+        return self._make_stats_diff(old_info, new_info)
+
+    def diff_datasource_mapping(self) -> dict:
+        new_mapping = self.new_src_build_reader.datasource_mapping
+        if not new_mapping:
+            raise ValueError(f"New Mapping cannot be empty. Build id: {self.new_src_build_reader.build_id}")
+        old_mapping = self.old_src_build_reader.datasource_mapping
+
+        return self._make_mapping_diff(old_mapping, new_mapping)
+
+    def to_dict(self) -> dict:
+        result = {
+            "old": {
+                "_version": self.old_src_build_reader.build_version,
+                "_count": self.old_src_build_reader.build_stats.get("total"),
+            },
+            "new": {
+                "_version": self.new_src_build_reader.build_version,
+                "_count": self.new_src_build_reader.build_stats.get("total"),
+                "_fields": self.diff_datasource_mapping(),
+                "_summary": self.diff_stats_from_metadata_file,
+            },
+
+            "stats": self.diff_build_stats(),
+            "sources": self.diff_datasource_info(),
+
+            "note": self.addon_note,
+            "generated_on": str(datetime.now().astimezone()),
+        }
+        return result
+
+
 class ReleaseNoteTxt(object):
-    def __init__(self, changes):
-        self.changes = changes
-        #pprint(self.changes)
+    def __init__(self, source: ReleaseNoteSource):
+        self.source = source  # member kept for debugging
+        self.changes = source.to_dict()
+
+    @classmethod
+    def _format_number(cls, num, sign=None):
+        try:
+            sign_symbol = ""
+            if sign:
+                if num > 0:
+                    sign_symbol = "+"
+                elif num < 0:
+                    sign_symbol = "-"
+
+            num_str = locale.format_string("%d", abs(num), grouping=True)
+
+            return "%s%s" % (sign_symbol, num_str)
+        except TypeError:
+            # something wrong with converting, maybe we don't even have a number to format...
+            return "N.A"
 
     def save(self, filepath):
         try:
             import prettytable
         except ImportError:
-            raise ImportError(
-                "Please install prettytable to use this rendered")
-
-        def format_number(n, sign=None):
-            s = ""
-            if sign:
-                if n > 0:
-                    s = "+"
-                elif n < 0:
-                    s = "-"
-            try:
-                n = abs(n)
-                strn = "%s%s" % (s, locale.format("%d", n, grouping=True))
-            except TypeError:
-                # something wrong with converting, maybe we don't even have a number to format...
-                strn = "N.A"
-            return strn
+            raise ImportError("Please install prettytable to use this rendered")
 
         txt = ""
         title = "Build version: '%s'" % self.changes["new"]["_version"]
         txt += title + "\n"
         txt += "".join(["="] * len(title)) + "\n"
         dt = dtparse(self.changes["generated_on"])
-        txt += "Previous build version: '%s'\n" % self.changes["old"][
-            "_version"]
+        txt += "Previous build version: '%s'\n" % self.changes["old"]["_version"]
         txt += "Generated on: %s\n" % dt.strftime("%Y-%m-%d at %H:%M:%S")
         txt += "\n"
 
@@ -51,61 +344,45 @@ class ReleaseNoteTxt(object):
         table.align["prev. # of docs"] = "r"
         table.align["new # of docs"] = "r"
 
-        for src, info in sorted(self.changes["sources"]["added"].items(),
-                                key=lambda e: e[0]):
-            main_info = dict([(k, v) for k, v in info.items()
-                              if k.startswith("_")])
-            sub_infos = dict([(k, v) for k, v in info.items()
-                              if not k.startswith("_")])
+        for src, info in sorted(self.changes["sources"]["added"].items(), key=lambda e: e[0]):
+            main_info = dict([(k, v) for k, v in info.items() if k.startswith("_")])
+            sub_infos = dict([(k, v) for k, v in info.items() if not k.startswith("_")])
             if sub_infos:
                 for sub, sub_info in sub_infos.items():
                     table.add_row([
-                        "%s.%s" % (src, sub), "-", main_info["_version"], "-",
-                        format_number(sub_info["_count"])
+                        "%s.%s" % (src, sub), "-", main_info["_version"], "-", self._format_number(sub_info["_count"])
                     ])  # only _count avail there
             else:
-                main_count = main_info.get("_count") and format_number(
-                    main_info["_count"]) or ""
-                table.add_row(
-                    [src, "-",
-                     main_info.get("_version", ""), "-", main_count])
-        for src, info in sorted(self.changes["sources"]["deleted"].items(),
-                                key=lambda e: e[0]):
-            main_info = dict([(k, v) for k, v in info.items()
-                              if k.startswith("_")])
-            sub_infos = dict([(k, v) for k, v in info.items()
-                              if not k.startswith("_")])
+                main_count = main_info.get("_count") and self._format_number(main_info["_count"]) or ""
+                table.add_row([
+                    src, "-", main_info.get("_version", ""), "-", main_count
+                ])
+
+        for src, info in sorted(self.changes["sources"]["deleted"].items(), key=lambda e: e[0]):
+            main_info = dict([(k, v) for k, v in info.items() if k.startswith("_")])
+            sub_infos = dict([(k, v) for k, v in info.items() if not k.startswith("_")])
             if sub_infos:
                 for sub, sub_info in sub_infos.items():
                     table.add_row([
-                        "%s.%s" % (src, sub),
-                        main_info.get("_version", ""), "-",
-                        format_number(sub_info["_count"]), "-"
+                        "%s.%s" % (src, sub), main_info.get("_version", ""), "-", self._format_number(sub_info["_count"]), "-"
                     ])  # only _count avail there
             else:
-                main_count = main_info.get("_count") and format_number(
-                    main_info["_count"]) or ""
-                table.add_row(
-                    [src,
-                     main_info.get("_version", ""), "-", main_count, "-"])
-        for src, info in sorted(self.changes["sources"]["updated"].items(),
-                                key=lambda e: e[0]):
+                main_count = main_info.get("_count") and self._format_number(main_info["_count"]) or ""
+                table.add_row([
+                    src, main_info.get("_version", ""), "-", main_count, "-"
+                ])
+
+        for src, info in sorted(self.changes["sources"]["updated"].items(), key=lambda e: e[0]):
             # extract information from main-source
-            old_main_info = dict([(k, v) for k, v in info["old"].items()
-                                  if k.startswith("_")])
-            new_main_info = dict([(k, v) for k, v in info["new"].items()
-                                  if k.startswith("_")])
-            old_main_count = old_main_info.get("_count") and format_number(
-                old_main_info["_count"]) or None
-            new_main_count = new_main_info.get("_count") and format_number(
-                new_main_info["_count"]) or None
+            old_main_info = dict([(k, v) for k, v in info["old"].items() if k.startswith("_")])
+            new_main_info = dict([(k, v) for k, v in info["new"].items() if k.startswith("_")])
+            old_main_count = old_main_info.get("_count") and self._format_number(old_main_info["_count"]) or None
+            new_main_count = new_main_info.get("_count") and self._format_number(new_main_info["_count"]) or None
             if old_main_count is None:
-                assert new_main_count is None, "Sub-sources found for '%s', old and new count should " % src + \
-                                               "both be None. Info was: %s" % info
-                old_sub_infos = dict([(k, v) for k, v in info["old"].items()
-                                      if not k.startswith("_")])
-                new_sub_infos = dict([(k, v) for k, v in info["new"].items()
-                                      if not k.startswith("_")])
+                assert new_main_count is None, \
+                    "Sub-sources found for '%s', old and new count should " % src + "both be None. Info was: %s" % info
+                old_sub_infos = dict([(k, v) for k, v in info["old"].items() if not k.startswith("_")])
+                new_sub_infos = dict([(k, v) for k, v in info["new"].items() if not k.startswith("_")])
                 # old & new sub_infos should have the same structure (same existing keys)
                 # so we just use one of them to explore
                 if old_sub_infos:
@@ -115,16 +392,17 @@ class ReleaseNoteTxt(object):
                             "%s.%s" % (src, sub),
                             old_main_info.get("_version", ""),
                             new_main_info.get("_version", ""),
-                            format_number(sub_info["_count"]),
-                            format_number(new_sub_infos[sub]["_count"])
+                            self._format_number(sub_info["_count"]),
+                            self._format_number(new_sub_infos[sub]["_count"])
                         ])
             else:
-                assert new_main_count is not None, "No sub-sources found, old and new count should NOT " + \
-                                                   "both be None. Info was: %s" % info
+                assert new_main_count is not None, \
+                    "No sub-sources found, old and new count should NOT " + "both be None. Info was: %s" % info
                 table.add_row([
                     src,
                     old_main_info.get("_version", ""),
-                    new_main_info.get("_version", ""), old_main_count,
+                    new_main_info.get("_version", ""),
+                    old_main_count,
                     new_main_count
                 ])
 
@@ -136,11 +414,9 @@ class ReleaseNoteTxt(object):
 
         total_count = self.changes["new"].get("_count")
         if self.changes["sources"]["added"]:
-            txt += "New datasource(s): %s\n" % ", ".join(
-                sorted(list(self.changes["sources"]["added"])))
+            txt += "New datasource(s): %s\n" % ", ".join(sorted(list(self.changes["sources"]["added"])))
         if self.changes["sources"]["deleted"]:
-            txt += "Deleted datasource(s): %s\n" % ", ".join(
-                sorted(list(self.changes["sources"]["deleted"])))
+            txt += "Deleted datasource(s): %s\n" % ", ".join(sorted(list(self.changes["sources"]["deleted"])))
         if self.changes["sources"]:
             txt += "\n"
 
@@ -148,27 +424,25 @@ class ReleaseNoteTxt(object):
         table.align["Updated stats."] = "l"
         table.align["previous"] = "r"
         table.align["new"] = "r"
-        for stat_name, stat in sorted(self.changes["stats"]["added"].items(),
-                                      key=lambda e: e[0]):
-            table.add_row([stat_name, "-", format_number(stat["_count"])])
-        for stat_name, stat in sorted(self.changes["stats"]["deleted"].items(),
-                                      key=lambda e: e[0]):
-            table.add_row([stat_name, format_number(stat["_count"]), "-"])
-        for stat_name, stat in sorted(self.changes["stats"]["updated"].items(),
-                                      key=lambda e: e[0]):
+        for stat_name, stat in sorted(self.changes["stats"]["added"].items(), key=lambda e: e[0]):
+            table.add_row([stat_name, "-", self._format_number(stat["_count"])])
+        for stat_name, stat in sorted(self.changes["stats"]["deleted"].items(), key=lambda e: e[0]):
+            table.add_row([stat_name, self._format_number(stat["_count"]), "-"])
+        for stat_name, stat in sorted(self.changes["stats"]["updated"].items(), key=lambda e: e[0]):
             table.add_row([
                 stat_name,
-                format_number(stat["old"]["_count"]),
-                format_number(stat["new"]["_count"])
+                self._format_number(stat["old"]["_count"]),
+                self._format_number(stat["new"]["_count"])
             ])
+
         if table._rows:
             txt += table.get_string()
             txt += "\n\n"
 
         if self.changes["new"]["_fields"]:
             new_fields = sorted(self.changes["new"]["_fields"].get("add", []))
-            deleted_fields = self.changes["new"]["_fields"].get("remove", [])
-            updated_fields = self.changes["new"]["_fields"].get("replace", [])
+            deleted_fields = sorted(self.changes["new"]["_fields"].get("remove", []))
+            updated_fields = sorted(self.changes["new"]["_fields"].get("replace", []))
             if new_fields:
                 txt += "New field(s): %s\n" % ", ".join(new_fields)
             if deleted_fields:
@@ -178,17 +452,13 @@ class ReleaseNoteTxt(object):
             txt += "\n"
 
         if total_count is not None:
-            txt += "Overall, %s documents in this release\n" % (
-                format_number(total_count))
+            txt += "Overall, %s documents in this release\n" % (self._format_number(total_count))
+
         if self.changes["new"]["_summary"]:
             sumups = []
-            sumups.append(
-                "%s document(s) added" %
-                format_number(self.changes["new"]["_summary"].get("add", 0)))
-            sumups.append("%s document(s) deleted" % format_number(
-                self.changes["new"]["_summary"].get("delete", 0)))
-            sumups.append("%s document(s) updated" % format_number(
-                self.changes["new"]["_summary"].get("update", 0)))
+            sumups.append("%s document(s) added" % self._format_number(self.changes["new"]["_summary"].get("add", 0)))
+            sumups.append("%s document(s) deleted" % self._format_number(self.changes["new"]["_summary"].get("delete", 0)))
+            sumups.append("%s document(s) updated" % self._format_number(self.changes["new"]["_summary"].get("update", 0)))
             txt += ", ".join(sumups) + "\n"
         else:
             txt += "No information available for added/deleted/updated documents\n"

--- a/tests/hub/datarelease/conftest.py
+++ b/tests/hub/datarelease/conftest.py
@@ -1,0 +1,30 @@
+import os
+import logging
+from dummy_config import HUB_DB_BACKEND, DATA_HUB_DB_DATABASE
+
+LOGGER = logging.getLogger(__name__)
+
+
+def pytest_sessionstart(session):
+    os.environ["HUB_CONFIG"] = "dummy_config"
+    LOGGER.info("os.environ['HUB_CONFIG'] set.")
+
+
+def pytest_sessionfinish(session):
+    del os.environ["HUB_CONFIG"]
+    LOGGER.info("os.environ['HUB_CONFIG'] reset.")
+
+    db_folder = HUB_DB_BACKEND.get("sqlite_db_folder", ".")
+    db_filename = DATA_HUB_DB_DATABASE
+    db_filepath = os.path.join(db_folder, db_filename)
+
+    if os.path.exists(db_filepath):
+        os.remove(db_filepath)
+        LOGGER.info(f"{db_filepath} deleted.")
+
+    if not os.listdir(db_folder):
+        LOGGER.info(f"{db_folder} is empty.")
+        os.rmdir(db_folder)
+        LOGGER.info(f"{db_folder} deleted.")
+    else:
+        LOGGER.info(f"{db_folder} not empty, kept as is.")

--- a/tests/hub/datarelease/dummy_config.py
+++ b/tests/hub/datarelease/dummy_config.py
@@ -1,0 +1,6 @@
+HUB_DB_BACKEND = {
+    "module": "biothings.utils.sqlite3",
+    "sqlite_db_folder": "./dummy_db"
+}
+
+DATA_HUB_DB_DATABASE = "dummy.hubdb"

--- a/tests/hub/datarelease/pytest.ini
+++ b/tests/hub/datarelease/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+log_cli = true
+log_cli_level = INFO

--- a/tests/hub/datarelease/test_releasenote.py
+++ b/tests/hub/datarelease/test_releasenote.py
@@ -1,0 +1,431 @@
+from copy import deepcopy
+import pytest
+from pytest_mock import MockerFixture
+from biothings.hub.datarelease.releasenote import ReleaseNoteSrcBuildReader, ReleaseNoteDatasourceInfoReader, \
+    ReleaseNoteSource, ReleaseNoteTxt
+
+
+@pytest.fixture
+def cold_src_build_doc():
+    src_build_doc = {
+        "_id": "warm_hg19_20220127_fpgrwjzd",
+        # "build_config":{
+        #     "cold_collection" : ""  # should not exist
+        # },
+        "_meta": {
+            "build_version": "20220127",
+            "stats": {
+                "hg19": 1367771989,
+                "vcf": 1369768159,
+                "observed": 1251513292,
+                "total": 1414567901
+            },
+            "src": {
+                "cosmic": {
+                    "version": "68",
+                    "stats": {
+                        "cosmic": 1024494
+                    }
+                },
+            },
+        },
+        "merge_stats": {
+            "cosmic": 1024494,
+        },
+        "mapping": {
+            "cosmic": {
+                "properties": {
+                    "chrom": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "hg19": {
+                        "properties": {
+                            "start": {
+                                "type": "integer"
+                            },
+                            "end": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "tumor_site": {
+                        "type": "text"
+                    },
+                    "cosmic_id": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "mut_nt": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "mut_freq": {
+                        "type": "float"
+                    },
+                    "ref": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "alt": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    }
+                }
+            },
+        }
+    }
+    return src_build_doc
+
+
+@pytest.fixture
+def hot_src_build_doc():
+    src_build_doc = {
+        "_id": "superhot_hg19_20220205_0v6out4e",
+        "build_config": {
+            "cold_collection": "warm_hg19_20220127_fpgrwjzd"
+        },
+        "_meta": {
+            "build_version": "20220205",
+            "stats": {
+                "total": 1420966502,
+                "hg19": 1367771989,
+                "vcf": 1369768159,
+                "observed": 1258678351
+            },
+            "src": {
+                "geno2mp": {
+                    "version": "2021-09-17",
+                    "stats": {
+                        "geno2mp": 37885228
+                    }
+                },
+                "clinvar": {
+                    "version": "2022-01",
+                    "stats": {
+                        "clinvar_hg19": 1126823
+                    }
+                },
+            }
+        },
+        "merge_stats": {
+            "clinvar_hg19": 1126823,
+            "geno2mp": 37885228
+        },
+        "mapping": {
+            "geno2mp": {
+                "properties": {
+                    "hpo_count": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "clinvar": {
+                "properties": {
+                    "hg19": {
+                        "properties": {
+                            "start": {
+                                "type": "integer"
+                            },
+                            "end": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "gene": {
+                        "properties": {
+                            "symbol": {
+                                "type": "text",
+                                "analyzer": "string_lowercase",
+                                "copy_to": [
+                                    "all"
+                                ]
+                            },
+                            "id": {
+                                "type": "long"
+                            }
+                        }
+                    },
+                    "type": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                    "rsid": {
+                        "type": "text",
+                        "analyzer": "string_lowercase"
+                    },
+                },
+            },
+        }
+    }
+    return src_build_doc
+
+
+@pytest.fixture
+def old_hot_src_build_docs(hot_src_build_doc):
+    # Do not use dict(hot_src_build_doc), that's a shallow copy
+    src_build_doc = deepcopy(hot_src_build_doc)
+
+    # change the contents on purpose to forge a doc for a previous build
+
+    src_build_doc["_id"] = "superhot_hg19_20210906_uthzjvjk"
+    src_build_doc["build_config"]["cold_collection"] = "warm_hg19_20210722_yz5tmmal"
+    src_build_doc["_meta"]["build_version"] = "20210906"
+
+    src_build_doc["_meta"]["stats"] = {
+        "total": 1420907501,
+        "hg19": 1367771989,
+        "vcf": 1369768159,
+        "observed": 1258602315
+    }
+
+    src_build_doc["_meta"]["src"] = {
+        "geno2mp": {
+            "version": "2021-01-28",
+            "stats": {
+                "geno2mp": 37557266
+            }
+        },
+        "clinvar": {
+            "version": "2021-08",
+            "stats": {
+                "clinvar_hg19": 990233
+            }
+        },
+    }
+
+    src_build_doc["merge_stats"] = {
+        "clinvar_hg19": 990233,
+        "geno2mp": 37557266
+    }
+
+    # delete a field
+    del src_build_doc["mapping"]["clinvar"]["properties"]["gene"]["properties"]["id"]
+    # add a field
+    src_build_doc["mapping"]["clinvar"]["properties"]["gene"]["properties"]["gene_id"] = {"type": "long"}
+    # modify a field
+    src_build_doc["mapping"]["clinvar"]["properties"]["type"]["type"] = "keyword"
+
+    return src_build_doc
+
+
+@pytest.fixture
+def old_cold_src_build_docs(cold_src_build_doc):
+    # Do not use dict(cold_src_build_doc), that's a shallow copy
+    src_build_doc = deepcopy(cold_src_build_doc)
+
+    # change the contents on purpose to forge a doc for a previous build
+
+    src_build_doc["_id"] = "warm_hg19_20210722_yz5tmmal"
+    src_build_doc["_meta"]["build_version"] = "20210722"
+
+    src_build_doc["_meta"]["stats"] = {
+        "total": 1414567743,
+        "hg19": 1367771989,
+        "vcf": 1369768159,
+        "observed": 1251513134
+    }
+
+    src_build_doc["_meta"]["src"] = {
+        "cosmic": {
+            "version": "67",
+            "stats": {
+                "cosmic": 1000000
+            }
+        },
+    }
+
+    src_build_doc["merge_stats"] = {
+        "cosmic": 1000000
+    }
+
+    # delete a field
+    del src_build_doc["mapping"]["cosmic"]["properties"]["mut_freq"]
+    # add a field
+    src_build_doc["mapping"]["cosmic"]["properties"]["mutation_frequency"] = {"type": "float"}
+    # modify a field
+    src_build_doc["mapping"]["cosmic"]["properties"]["ref"]["type"] = "keyword"
+
+    return src_build_doc
+
+
+@pytest.fixture
+def mock_get_source_fullname(mocker: MockerFixture):
+    def mock_fn(col_name):
+        source_fullname_map = {
+            "cosmic": "cosmic",
+            "geno2mp": "geno2mp",
+            "clinvar_hg19": "clinvar.clinvar_hg19"
+        }
+
+        if col_name in source_fullname_map:
+            return source_fullname_map[col_name]
+
+        raise ValueError(f"behavior is not mocked when input col_name is f{col_name}.")
+
+    # should not be "biothings.utils.hub_db.get_source_fullname", nor "biothings.utils.sqlite3.get_source_fullname"
+    return mocker.patch("biothings.hub.datarelease.releasenote.get_source_fullname", mock_fn)
+
+
+@pytest.mark.ReleaseNoteSrcBuildReader
+def test_reading_cold_src_build(cold_src_build_doc):
+    cold_doc = cold_src_build_doc
+    cold_reader = ReleaseNoteSrcBuildReader(cold_doc)
+
+    assert cold_reader.build_id == cold_doc["_id"]
+    assert cold_reader.build_version == cold_doc["_meta"]["build_version"]
+    assert cold_reader.build_stats == cold_doc["_meta"]["stats"]
+
+    assert cold_reader.cold_src_build_reader is None
+    assert cold_reader.cold_collection_name is None
+    with pytest.raises(ValueError):
+        cold_reader.attach_cold_src_build_reader(ReleaseNoteSrcBuildReader(cold_src_build_doc))
+
+    assert cold_reader.datasource_versions == {"cosmic": "68"}
+    assert cold_reader.datasource_stats == cold_doc["merge_stats"]
+    assert cold_reader.datasource_mapping == cold_doc["mapping"]
+
+
+@pytest.mark.ReleaseNoteSrcBuildReader
+def test_reading_hot_src_build(hot_src_build_doc, cold_src_build_doc):
+    hot_doc = hot_src_build_doc
+    hot_reader = ReleaseNoteSrcBuildReader(hot_doc)
+
+    cold_doc = cold_src_build_doc
+    cold_reader = ReleaseNoteSrcBuildReader(cold_doc)
+
+    hot_reader.attach_cold_src_build_reader(cold_reader)
+
+    assert hot_reader.build_id == hot_doc["_id"]
+    assert hot_reader.build_version == hot_doc["_meta"]["build_version"]
+    assert hot_reader.build_stats == hot_doc["_meta"]["stats"]
+
+    assert hot_reader.cold_src_build_reader is not None
+    assert hot_reader.cold_collection_name == hot_doc["build_config"]["cold_collection"]
+
+    assert hot_reader.datasource_versions == {'clinvar': hot_doc["_meta"]["src"]["clinvar"]["version"],
+                                              "cosmic": cold_doc["_meta"]["src"]["cosmic"]["version"],
+                                              "geno2mp": hot_doc["_meta"]["src"]["geno2mp"]["version"]}
+    assert hot_reader.datasource_stats == {**hot_doc["merge_stats"], **cold_doc["merge_stats"]}
+    assert hot_reader.datasource_mapping == {**hot_doc["mapping"], **cold_doc["mapping"]}
+
+
+@pytest.mark.ReleaseNoteDatasourceInfoReader
+def test_reading_cold_datasource_info(mock_get_source_fullname, cold_src_build_doc):
+    cold_doc = cold_src_build_doc
+    cold_reader = ReleaseNoteSrcBuildReader(cold_doc)
+    datasource_info_reader = ReleaseNoteDatasourceInfoReader(cold_reader)
+
+    info = datasource_info_reader.datasource_info
+    assert len(info) == 1
+    assert info["cosmic"] == {'_version': cold_doc["_meta"]["src"]["cosmic"]["version"],
+                              '_count': cold_doc["merge_stats"]["cosmic"]}
+
+
+@pytest.mark.ReleaseNoteDatasourceInfoReader
+def test_reading_hot_datasource_info(mock_get_source_fullname, cold_src_build_doc, hot_src_build_doc):
+    hot_doc = hot_src_build_doc
+    cold_doc = cold_src_build_doc
+
+    hot_reader = ReleaseNoteSrcBuildReader(hot_doc)
+    cold_reader = ReleaseNoteSrcBuildReader(cold_doc)
+    hot_reader.attach_cold_src_build_reader(cold_reader)
+
+    datasource_info_reader = ReleaseNoteDatasourceInfoReader(hot_reader)
+
+    info = datasource_info_reader.datasource_info
+    assert len(info) == 3
+    assert info["geno2mp"] == {'_version': hot_doc["_meta"]["src"]["geno2mp"]["version"],
+                               '_count': hot_doc["merge_stats"]["geno2mp"]}
+    assert info["cosmic"] == {'_version': cold_doc["_meta"]["src"]["cosmic"]["version"],
+                              '_count': cold_doc["merge_stats"]["cosmic"]}
+    assert info["clinvar"] == {'_version': hot_doc["_meta"]["src"]["clinvar"]["version"],
+                               'clinvar_hg19': {'_count': hot_doc["merge_stats"]["clinvar_hg19"]}}
+
+
+@pytest.fixture
+def release_note_source(mock_get_source_fullname, cold_src_build_doc, hot_src_build_doc,
+                        old_cold_src_build_docs, old_hot_src_build_docs):
+    old_src_build_reader = ReleaseNoteSrcBuildReader(old_hot_src_build_docs)
+    old_src_build_reader.attach_cold_src_build_reader(ReleaseNoteSrcBuildReader(old_cold_src_build_docs))
+
+    new_src_build_reader = ReleaseNoteSrcBuildReader(hot_src_build_doc)
+    new_src_build_reader.attach_cold_src_build_reader(ReleaseNoteSrcBuildReader(cold_src_build_doc))
+
+    diff_stats_from_metadata_file = {"foo": "bar", "baz": "qux"}
+    addon_note = "FooBarBazQux"
+
+    source = ReleaseNoteSource(old_src_build_reader=old_src_build_reader,
+                               new_src_build_reader=new_src_build_reader,
+                               diff_stats_from_metadata_file=diff_stats_from_metadata_file,
+                               addon_note=addon_note)
+    return source
+
+
+@pytest.mark.ReleaseNoteSource
+def test_diff_datasource_mapping(release_note_source):
+    diff = release_note_source.diff_datasource_mapping()
+
+    assert len(diff) == 3
+    assert set(diff["add"]) == set(['clinvar.gene.id', 'cosmic.mut_freq'])
+    assert set(diff["remove"]) == set(['clinvar.gene.gene_id', 'cosmic.mutation_frequency'])
+    assert set(diff["replace"]) == set(['clinvar.type.type', 'cosmic.ref.type'])
+
+
+@pytest.mark.ReleaseNoteSource
+def test_diff_build_stats(release_note_source):
+    new_doc = release_note_source.new_src_build_reader.src_build_doc
+    old_doc = release_note_source.old_src_build_reader.src_build_doc
+
+    diff = release_note_source.diff_build_stats()
+    assert len(diff) == 3
+    assert diff["added"] == {}
+    assert diff["deleted"] == {}
+
+    assert len(diff["updated"]) == 2
+    assert diff["updated"]["total"] == {"new": new_doc["_meta"]["stats"]["total"],
+                                        "old": old_doc["_meta"]["stats"]["total"]}
+    assert diff["updated"]["observed"] == {"new": new_doc["_meta"]["stats"]["observed"],
+                                           "old": old_doc["_meta"]["stats"]["observed"]}
+
+
+@pytest.mark.ReleaseNoteSource
+def test_diff_datasource_info(release_note_source):
+    new_hot_doc = release_note_source.new_src_build_reader.src_build_doc
+    new_cold_doc = release_note_source.new_src_build_reader.cold_src_build_reader.src_build_doc
+    old_hot_doc = release_note_source.old_src_build_reader.src_build_doc
+    old_cold_doc = release_note_source.old_src_build_reader.cold_src_build_reader.src_build_doc
+
+    diff = release_note_source.diff_datasource_info()
+
+    assert len(diff) == 3
+    assert diff["added"] == {}
+    assert diff["deleted"] == {}
+
+    assert len(diff["updated"]) == 3
+    assert len(diff["updated"]["geno2mp"]) == 2
+    assert len(diff["updated"]["clinvar"]) == 2
+    assert len(diff["updated"]["cosmic"]) == 2
+    assert diff["updated"]["geno2mp"]["new"] == {'_version': new_hot_doc["_meta"]["src"]["geno2mp"]["version"],
+                                                 '_count': new_hot_doc["merge_stats"]["geno2mp"]}
+    assert diff["updated"]['geno2mp']["old"] == {'_version': old_hot_doc["_meta"]["src"]["geno2mp"]["version"],
+                                                 '_count': old_hot_doc["merge_stats"]["geno2mp"]}
+    assert diff["updated"]["clinvar"]["new"] == {'_version': new_hot_doc["_meta"]["src"]["clinvar"]["version"],
+                                                 'clinvar_hg19': {'_count': new_hot_doc["merge_stats"]["clinvar_hg19"]}}
+    assert diff["updated"]['clinvar']["old"] == {'_version': old_hot_doc["_meta"]["src"]["clinvar"]["version"],
+                                                 'clinvar_hg19': {'_count': old_hot_doc["merge_stats"]["clinvar_hg19"]}}
+    assert diff["updated"]["cosmic"]["new"] == {'_version': new_cold_doc["_meta"]["src"]["cosmic"]["version"],
+                                                '_count': new_cold_doc["merge_stats"]["cosmic"]}
+    assert diff["updated"]['cosmic']["old"] == {'_version': old_cold_doc["_meta"]["src"]["cosmic"]["version"],
+                                                '_count': old_cold_doc["merge_stats"]["cosmic"]}
+
+
+@pytest.mark.ReleaseNoteTxt
+def test_format_number():
+    assert ReleaseNoteTxt._format_number(0) == "0"
+    assert ReleaseNoteTxt._format_number(0, sign=True) == "0"
+
+    assert ReleaseNoteTxt._format_number(1, sign=True) == "+1"
+    assert ReleaseNoteTxt._format_number(-1, sign=True) == "-1"
+
+    assert ReleaseNoteTxt._format_number("one", sign=True) == "N.A"


### PR DESCRIPTION
The whole fix involves two parts:

- **Biothings.api Implementation:** When generating a release note between two builds, $x$ and $y$, the Publisher in Biothings.api codebase will read 3 major pieces of information for each build, i.e. _**build stats**_, _**datasource stats**_, and _**mappings**_. However, if a build $x$ has a `cold_collection`, which corresponds to another build $x'$, the Publisher should read the combined stats/mappings of $x$ and $x'$.
    1. For _**build stats**_, the Publisher will read the combined stats in $x$, no need to read $x'$.
    1. For _**datasource stats**_, the Publisher will read the datasource fields in both $x$ and $x'$
    1. For _**mappings**_, the Publisher will read the mapping fields in both $x$ and $x'$
Note that **Biothings.api Implementatio** should work **compatibly** even if build $x$ is a vanilla  without a `cold_collection`.
- **MyVariant.info Implementation:** The MyVariant indexer should update the _**build stats**_ of $x$ (in **post-index** steps). Previously we only updated the build stats to ES mapping `meta` field. Such build stats should also be written into MongoDB.

This PR is the **Biothings.api Implementation**.

P.S. **MyVariant.info Implementation** is proposed by https://github.com/biothings/myvariant.info/pull/146