### PR TITLE
metadata query logical enhancements and bugfixes

### DIFF
--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -354,7 +354,6 @@ class QStringParser:
         pattern matching against the query, we simply set the `query_object` to the default instance
         6) We return the constructed Query instance to the caller
         """
-        breakpoint()
         logger.debug("Attempting to parse query string %s", query)
         query_metadata = self._build_endpoint_metadata_fields(metadata)
 

--- a/biothings/web/services/namespace.py
+++ b/biothings/web/services/namespace.py
@@ -95,28 +95,36 @@ class BiothingsNamespace:
             self.config.ES_INDICES,
             self.elasticsearch.async_client,
         )
+
+        elasticsearch_result_formatter = load_class(self.config.ES_RESULT_TRANSFORM)(
+            self.elasticsearch.metadata.biothing_licenses,
+            self.config.LICENSE_TRANSFORM,
+            self.fieldnote.get_field_notes(),
+            self.config.AVAILABLE_FIELDS_EXCLUDED,
+        )
+
+        elasticsearch_query_backend = load_class(self.config.ES_QUERY_BACKEND)(
+            self.elasticsearch.async_client,
+            self.config.ES_INDICES,
+            self.config.ES_SCROLL_TIME,
+            self.config.ES_SCROLL_SIZE,
+        )
+
+        elasticsearch_query_builder = load_class(self.config.ES_QUERY_BUILDER)(
+            self.elasticsearch.userquery,
+            self.config.ANNOTATION_ID_REGEX_LIST,
+            self.config.ANNOTATION_DEFAULT_SCOPES,
+            self.config.ANNOTATION_DEFAULT_REGEX_PATTERN,
+            self.config.ALLOW_RANDOM_QUERY,
+            self.config.ALLOW_NESTED_AGGS,
+            self.elasticsearch.metadata,
+            elasticsearch_result_formatter,
+        )
+
         self.elasticsearch.pipeline = load_class(self.config.ES_QUERY_PIPELINE)(
-            load_class(self.config.ES_QUERY_BUILDER)(
-                self.elasticsearch.userquery,
-                self.config.ANNOTATION_ID_REGEX_LIST,
-                self.config.ANNOTATION_DEFAULT_SCOPES,
-                self.config.ANNOTATION_DEFAULT_REGEX_PATTERN,
-                self.config.ALLOW_RANDOM_QUERY,
-                self.config.ALLOW_NESTED_AGGS,
-                self.elasticsearch.metadata,
-            ),
-            load_class(self.config.ES_QUERY_BACKEND)(
-                self.elasticsearch.async_client,
-                self.config.ES_INDICES,
-                self.config.ES_SCROLL_TIME,
-                self.config.ES_SCROLL_SIZE,
-            ),
-            load_class(self.config.ES_RESULT_TRANSFORM)(
-                self.elasticsearch.metadata.biothing_licenses,
-                self.config.LICENSE_TRANSFORM,
-                self.fieldnote.get_field_notes(),
-                self.config.AVAILABLE_FIELDS_EXCLUDED,
-            ),
+            elasticsearch_query_backend,
+            elasticsearch_query_builder,
+            elasticsearch_result_formatter,
             fetch_max_match=self.config.ANNOTATION_MAX_MATCH,
         )
         self.elasticsearch.health = ESHealth(self.elasticsearch.async_client, self.config.STATUS_CHECK)

--- a/biothings/web/services/namespace.py
+++ b/biothings/web/services/namespace.py
@@ -122,8 +122,8 @@ class BiothingsNamespace:
         )
 
         self.elasticsearch.pipeline = load_class(self.config.ES_QUERY_PIPELINE)(
-            elasticsearch_query_backend,
             elasticsearch_query_builder,
+            elasticsearch_query_backend,
             elasticsearch_result_formatter,
             fetch_max_match=self.config.ANNOTATION_MAX_MATCH,
         )


### PR DESCRIPTION
This add the `ESResultFormatter` to the query builder so that when we extract the metadata fields for the endpoint, we include all fields and properties of the fields as well when we create the full set