### PR TITLE
Add more idiomatic sqlite multiple document insert

### DIFF
--- a/biothings/utils/sqlite3.py
+++ b/biothings/utils/sqlite3.py
@@ -352,9 +352,7 @@ class Collection(object):
                 conn.execute(sql_statement, parameters)
             except sqlite3.IntegrityError as integrity_err:
                 logger.exception(integrity_err)
-                logger.error(
-                    ("Unable to complete transation (check the _id value for uniqueness). " f"Document: {doc}")
-                )
+                logger.error("Unable to complete transation (check the _id value for uniqueness). Document: %s", doc)
                 raise integrity_err
 
     def insert(self, docs: list[dict]) -> None:
@@ -394,9 +392,9 @@ class Collection(object):
                     logger.error("Discovered non-unique id values: %s", discovered_non_unique_id)
                 raise integrity_err
 
-    def bulk_write(self, docs, *args, **kwargs):
+    def bulk_write(self, docs: list[dict]) -> sqlite3.Cursor:
         doc_objs = [item._doc for item in docs]
-        self.insert(doc_objs, *args, **kwargs)
+        self.insert(doc_objs)
         return Cursor(len(doc_objs))
 
     def update_one(self, query, what, upsert=False):

--- a/biothings/utils/sqlite3.py
+++ b/biothings/utils/sqlite3.py
@@ -349,7 +349,6 @@ class Collection(object):
             try:
                 parameters = (doc["_id"], json.dumps(doc, default=json_serial))
                 sql_statement = f"INSERT INTO {self.colname} (_id,document) VALUES (?,?)"
-                breakpoint()
                 conn.execute(sql_statement, parameters)
             except sqlite3.IntegrityError as integrity_err:
                 logger.exception(integrity_err)
@@ -381,7 +380,6 @@ class Collection(object):
         with self.get_conn() as conn:
             rendered_documents = [{"_id": doc["_id"], "repr": json.dumps(doc, default=json_serial)} for doc in docs]
             try:
-                breakpoint()
                 sql_statement = f"INSERT INTO {self.colname} (_id,document) VALUES (:_id, :repr)"
                 conn.executemany(sql_statement, rendered_documents)
             except sqlite3.IntegrityError as integrity_err:

--- a/biothings/utils/sqlite3.py
+++ b/biothings/utils/sqlite3.py
@@ -347,8 +347,9 @@ class Collection(object):
         """
         with self.get_conn() as conn:
             try:
-                parameters = ((doc["_id"], json.dumps(doc, default=json_serial)),)
+                parameters = (doc["_id"], json.dumps(doc, default=json_serial))
                 sql_statement = f"INSERT INTO {self.colname} (_id,document) VALUES (?,?)"
+                breakpoint()
                 conn.execute(sql_statement, parameters)
             except sqlite3.IntegrityError as integrity_err:
                 logger.exception(integrity_err)
@@ -380,6 +381,7 @@ class Collection(object):
         with self.get_conn() as conn:
             rendered_documents = [{"_id": doc["_id"], "repr": json.dumps(doc, default=json_serial)} for doc in docs]
             try:
+                breakpoint()
                 sql_statement = f"INSERT INTO {self.colname} (_id,document) VALUES (:_id, :repr)"
                 conn.executemany(sql_statement, rendered_documents)
             except sqlite3.IntegrityError as integrity_err:

--- a/biothings/utils/sqlite3.py
+++ b/biothings/utils/sqlite3.py
@@ -336,7 +336,7 @@ class Collection(object):
         else:
             raise NotImplementedError("find: args=%s kwargs=%s" % (repr(args), repr(kwargs)))
 
-    def insert_one(self, doc: dict) -> None:
+    def insert_one(self, doc: dict, *args, **kwargs) -> None:
         """
         single-document insert into the database
 
@@ -355,7 +355,7 @@ class Collection(object):
                 logger.error("Unable to complete transation (check the _id value for uniqueness). Document: %s", doc)
                 raise integrity_err
 
-    def insert(self, docs: list[dict]) -> None:
+    def insert(self, docs: list[dict], *args, **kwargs) -> None:
         """
         multi-document insert into the database
 
@@ -392,7 +392,7 @@ class Collection(object):
                     logger.error("Discovered non-unique id values: %s", discovered_non_unique_id)
                 raise integrity_err
 
-    def bulk_write(self, docs: list[dict]) -> sqlite3.Cursor:
+    def bulk_write(self, docs: list[dict], *args, **kwargs) -> sqlite3.Cursor:
         doc_objs = [item._doc for item in docs]
         self.insert(doc_objs)
         return Cursor(len(doc_objs))


### PR DESCRIPTION
Here's some performance metrics on a relatively small plugin of ~50k documents
```
<new branch>
(biothings) jschaff@tsri-ubuntu:~/workspace/biothings/pending.api/plugins/fda_drugs$ biothings-cli dataplugin upload
[15:58:38] INFO     Registering 'fda_drugs' to dump/upload managers 
           INFO     Uploading to the DB...
[15:58:39] INFO     insert time: 0.22862836300009803
           INFO     insert time: 0.06624280699907104
           INFO     insert time: 0.06812734000050114
           INFO     insert time: 0.07389820600110397
           INFO     insert time: 0.058063160000529024
           INFO     Done[0.92s] with 48022 docs
           INFO     Renaming collection 'fda_drugs' to 'fda_drugs_archive_20240506_ukQtnR1S' for archiving purpose.
           INFO     Renaming collection 'fda_drugs_temp_KACOAEWD' to 'fda_drugs'
           INFO     Cleaning old archive/temp collection 'fda_drugs_archive_20240429_Hf5y8MGK'
           INFO     Success! 🚀
           INFO     No manifest file discovered

<old_branch>
(biothings) jschaff@tsri-ubuntu:~/workspace/biothings/pending.api/plugins/fda_drugs$ biothings-cli dataplugin upload
[16:07:46] INFO     Registering 'fda_drugs' to dump/upload managers
           INFO     Uploading to the DB...
[16:07:59] INFO     insert time: 12.146238160999928
[16:08:11] INFO     insert time: 12.159127867998905
[16:08:23] INFO     insert time: 12.154233698998723
[16:08:35] INFO     insert time: 12.135395965999123
[16:08:45] INFO     insert time: 9.772147027000756
           INFO     Done[58.93s] with 48022 docs
           INFO     Renaming collection 'fda_drugs' to 'fda_drugs_archive_20240506_YtAAjEfK' for archiving purpose.
           INFO     Renaming collection 'fda_drugs_temp_fxM8B1uu' to 'fda_drugs'
           INFO     Cleaning old archive/temp collection 'fda_drugs_archive_20240503_1qn2LgNk'
           INFO     Success! 🚀
           INFO     No manifest file discovered
```

I've also uploaded a [dump](https://github.com/biothings/biothings.api/files/15238703/dump.tar.gz) of the database table generated to prove that the data is identical
