### PR TITLE
Add id checking to IgnoreDuplicatedStorage ...

### DIFF
--- a/biothings/cli/utils.py
+++ b/biothings/cli/utils.py
@@ -263,7 +263,6 @@ def do_upload(plugin_name=None, show_uploaded=True, logger=None):
     _plugin = load_plugin(plugin_name, dumper=False, uploader=True, logger=logger)
     for uploader_cls in _plugin.uploader_classes:
         uploader = uploader_cls.create(db_conn_info="")
-        breakpoint()
         uploader.make_temp_collection()
         uploader.prepare()
         if not uploader.data_folder or not pathlib.Path(uploader.data_folder).exists():

--- a/biothings/cli/utils.py
+++ b/biothings/cli/utils.py
@@ -263,6 +263,7 @@ def do_upload(plugin_name=None, show_uploaded=True, logger=None):
     _plugin = load_plugin(plugin_name, dumper=False, uploader=True, logger=logger)
     for uploader_cls in _plugin.uploader_classes:
         uploader = uploader_cls.create(db_conn_info="")
+        breakpoint()
         uploader.make_temp_collection()
         uploader.prepare()
         if not uploader.data_folder or not pathlib.Path(uploader.data_folder).exists():

--- a/biothings/hub/dataload/uploader.py
+++ b/biothings/hub/dataload/uploader.py
@@ -255,7 +255,8 @@ class BaseSourceUploader(object):
             self.db[colname].drop()
 
     def switch_collection(self):
-        """after a successful loading, rename temp_collection to regular collection name,
+        """
+        after a successful loading, rename temp_collection to regular collection name,
         and renaming existing collection to a temp name for archiving purpose.
         """
         if self.temp_collection_name and self.db[self.temp_collection_name].count() > 0:

--- a/biothings/utils/storage.py
+++ b/biothings/utils/storage.py
@@ -2,6 +2,7 @@ import copy
 import logging
 import time
 import types
+from typing import Iterable
 
 from sqlite3 import IntegrityError
 
@@ -206,10 +207,8 @@ class IgnoreDuplicatedStorage(BasicStorage):
                 break
             batch_num += 1
             try:
-                bulk = []
-                for d in doc_li:
-                    bulk.append(InsertOne(d))
-                res = self.temp_collection.bulk_write(bulk, ordered=False)
+                bulk_set = [InsertOne(document) for document in self.unique_documents(doc_li)]
+                res = self.temp_collection.bulk_write(bulk_set, ordered=False)
                 total += res.inserted_count
                 self.logger.info("Inserted %s records [%s]" % (res.inserted_count, timesofar(tinner)))
             except BulkWriteError as e:
@@ -217,19 +216,35 @@ class IgnoreDuplicatedStorage(BasicStorage):
                     "Inserted %s records, ignoring %d [%s]"
                     % (e.details["nInserted"], len(e.details["writeErrors"]), timesofar(tinner))
                 )
-            except IntegrityError as e:
-                self.logger.info(f"Skipping duplicate record. Details: {e}")
-            except Exception:
-                raise
+            except IntegrityError as integrity_error:
+                self.logger.warning(f"Skipping duplicate record. Details: {integrity_error}")
+            except Exception as gen_exp:
+                self.logger.exception(gen_exp)
+                raise gen_exp
             tinner = time.time()
         self.logger.info("Done[%s]" % timesofar(t0))
 
         return total
 
+    def unique_documents(self, documents: Iterable[dict]) -> list[dict]:
+        """
+        Generates the set of id values from the provided batch of documents
+        due to our documents being unhashable
+
+        We then filter the documents to only the unique ID values which should eliminate
+        any uniqueness constraint issues when uploading to the database
+
+        Returns a list of filtered documents
+        """
+        unique_documents = list({document["_id"]: document for document in documents}.values())
+        if len(unique_documents) < len(documents):
+            self.logger.debug("Filtered %s documents before upload", len(documents) - len(unique_documents))
+        return unique_documents
+
 
 class NoBatchIgnoreDuplicatedStorage(BasicStorage):
     """
-    You should use IgnoreDuplicatedStorag, which works using batch
+    You should use IgnoreDuplicatedStorage, which works using batch
     and is thus way faster...
     """
 


### PR DESCRIPTION
For the sequential case, this storage works as expected because each document is checked for uniqueness. When processing this in batch, there needs to be some more filtering involved especially if the number of document is small with a higher ratio of duplicates in those documents.

If you attempt to upload to the database and each batch has duplicates in it, the entire batch will continually get thrown out until no documents were actually uploaded to the database. Instead if we verify the uniqueness constraint prior to uploading by ensuring we have a one-to-one ratio of id to documents in our collection, then we can ensure a safe upload.

This still discards identifical or near identical documents without throwing out an entire batch of potentially valid documents in the batch upload