### PR TITLE
Build Config Err Fix

### DIFF
--- a/biothings/hub/databuild/builder.py
+++ b/biothings/hub/databuild/builder.py
@@ -1530,8 +1530,8 @@ class BuilderManager(BaseManager):
 
     def build_config_info(self):
         configs = {}
-        err = None
         for name in self.register:
+            err = None
             try:
                 builder = self[name]
             except Exception as e:


### PR DESCRIPTION
In the event an error occurs in one build config, every item in the list afterwards will contain the error. Resetting the error to None inside the loop fixes this.