### PR TITLE
Fix Unlisting Logic in Dataload Utils

### DIFF
--- a/biothings/utils/dataload.py
+++ b/biothings/utils/dataload.py
@@ -269,7 +269,7 @@ def unlist(d):
             d[key] = unlist(val)
     return d
 
-
+# Internal helper function called by unlist_incexcl
 def _should_unlist(path, include_keys=None, exclude_keys=None):
     if include_keys is not None and exclude_keys is not None:
         return path in include_keys and path not in exclude_keys
@@ -279,7 +279,7 @@ def _should_unlist(path, include_keys=None, exclude_keys=None):
         return path not in exclude_keys
     return True
 
-
+# Internal helper function called by unlist_incexcl
 def _unlist_helper(d, include_keys=None, exclude_keys=None, keys=None):
     keys = keys or []
     if isinstance(d, dict):

--- a/biothings/utils/dataload.py
+++ b/biothings/utils/dataload.py
@@ -250,52 +250,66 @@ def rec_handler(infile, block_end="\n", skip=0, include_block_end=False, as_list
 # ===============================================================================
 
 
-# if dict value is a list of length 1, unlist
 def unlist(d):
+    """Recursively unlist elements in a dictionary.
+
+    If an element in a list is a dictionary, apply the unlist function to it recursively.
+    If a list contains only one element, replace the list with that single element.
+    The function operates on all keys within the dictionary.
+
+    :param d: a dictionary to unlist
+    :return: the modified dictionary with unlisted elements
+    """
     for key, val in d.items():
         if isinstance(val, list):
-            if len(val) == 1:
-                d[key] = val[0]
+            d[key] = [unlist(v) if isinstance(v, dict) else v for v in val]
+            if len(d[key]) == 1:
+                d[key] = d[key][0]
         elif isinstance(val, dict):
-            unlist(val)
+            d[key] = unlist(val)
     return d
 
 
 def unlist_incexcl(d, include_keys=None, exclude_keys=None):
     """Unlist elements in a document.
 
-    If there is 1 value in the list, set the element to that value.  Otherwise,
+    If there is 1 value in the list, set the element to that value. Otherwise,
     leave the list unchanged.
 
-    By default, traverse all keys
-    If include_keys is specified, only traverse the list from include_keys a.b, a.b.c
-    If exclude_keys is specified, only exclude the list from exclude_keys
+    By default, traverse all keys.
+    If include_keys is specified, only traverse the list for keys in include_keys.
+    If exclude_keys is specified, exclude the list for keys in exclude_keys.
 
     :param d: a dictionary to unlist
     :param include_keys: only unlist these keys (optional)
     :param exclude_keys: exclude all other keys except these keys (optional)
-    :return: generate key, value pairs
+    :return: the modified dictionary
     """
 
-    def unlist_helper(d, include_keys=None, exclude_keys=None, keys=None):
-        include_keys = include_keys or []
-        exclude_keys = exclude_keys or []
+    def should_unlist(path):
+        if include_keys is not None and exclude_keys is not None:
+            return path in include_keys and path not in exclude_keys
+        elif include_keys is not None:
+            return path in include_keys
+        elif exclude_keys is not None:
+            return path not in exclude_keys
+        return True
+
+    def unlist_helper(d, keys=None):
         keys = keys or []
         if isinstance(d, dict):
-            for key, val in d.items():
+            for key, val in list(d.items()):
+                path = ".".join(keys + [key])
                 if isinstance(val, list):
-                    if len(val) == 1:
-                        path = ".".join(keys + [key])
-                        if include_keys:
-                            if path in include_keys:
-                                d[key] = val[0]
-                        elif path not in exclude_keys:
-                            d[key] = val[0]
+                    if len(val) == 1 and should_unlist(path):
+                        d[key] = unlist_helper(val[0], keys + [key])
+                    else:
+                        d[key] = [unlist_helper(item, keys + [key]) for item in val]
                 elif isinstance(val, dict):
-                    unlist_helper(val, include_keys, exclude_keys, keys + [key])
+                    d[key] = unlist_helper(val, keys + [key])
+        return d
 
-    unlist_helper(d, include_keys, exclude_keys, [])
-    return d
+    return unlist_helper(d)
 
 
 def list_split(d, sep):

--- a/tests/hub/dataload/unlist.py
+++ b/tests/hub/dataload/unlist.py
@@ -1,0 +1,89 @@
+import unittest
+
+from biothings.utils.dataload import unlist
+
+class TestUnlistFunction(unittest.TestCase):
+    def test_single_element_list(self):
+        """
+        Test unlisting a single element list.
+        :return:
+        """
+        data = {'key': ['value']}
+        expected = {'key': 'value'}
+        self.assertEqual(unlist(data), expected)
+
+    def test_single_element_nested_list(self):
+        """
+        Test unlisting a single element nested list.
+        :return:
+        """
+        data = {'key': [{'subkey': ['subvalue']}]}
+        expected = {'key': {'subkey': 'subvalue'}}
+        self.assertEqual(unlist(data), expected)
+
+    def test_multiple_element_list(self):
+        """
+        Test that a multiple element list is not unlisted.
+        :return:
+        """
+        data = {'key': ['value1', 'value2']}
+        expected = {'key': ['value1', 'value2']}
+        self.assertEqual(unlist(data), expected)
+
+    def test_nested_dict_with_single_element_list(self):
+        """
+        Test unlisting a nested dictionary with single element list.
+        :return:
+        """
+        data = {'gene': [{'id': 1017, 'source': ['clinvar']}, {'id': 1018, 'source': ['bg']}]}
+        expected = {'gene': [{'id': 1017, 'source': 'clinvar'}, {'id': 1018, 'source': 'bg'}]}
+        self.assertEqual(unlist(data), expected)
+
+    def test_nested_dict_with_multiple_element_list(self):
+        """
+        Test nested dictionary with multiple element list, ensuring no unlisting.
+        :return:
+        """
+        data = {'gene': [{'id': 1017, 'source': ['clinvar', 'dbsnp']}, {'id': 1018, 'source': ['bg']}]}
+        expected = {'gene': [{'id': 1017, 'source': ['clinvar', 'dbsnp']}, {'id': 1018, 'source': 'bg'}]}
+        self.assertEqual(unlist(data), expected)
+
+    def test_empty_list(self):
+        """
+        Test that an empty list remains unchanged.
+        :return:
+        """
+        data = {'key': []}
+        expected = {'key': []}
+        self.assertEqual(unlist(data), expected)
+
+    def test_no_list(self):
+        """
+        Test that a value without a list remains unchanged.
+        :return:
+        """
+        data = {'key': 'value'}
+        expected = {'key': 'value'}
+        self.assertEqual(unlist(data), expected)
+
+    def test_deeply_nested_single_element_list(self):
+        """
+        Test unlisting a deeply nested single element list.
+        :return:
+        """
+        data = {'key': {'subkey': [{'subsubkey': ['subsubvalue']}]} }
+        expected = {'key': {'subkey': {'subsubkey': 'subsubvalue'}} }
+        self.assertEqual(unlist(data), expected)
+
+    def test_no_change_needed(self):
+        """
+        Test that no changes are made if no unlisting is needed.
+        :return:
+        """
+        data = {'key': {'subkey': 'subvalue'}}
+        expected = {'key': {'subkey': 'subvalue'}}
+        self.assertEqual(unlist(data), expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/hub/dataload/unlist_incexcl.py
+++ b/tests/hub/dataload/unlist_incexcl.py
@@ -1,0 +1,160 @@
+import unittest
+
+from biothings.utils.dataload import unlist_incexcl
+
+class TestUnlistIncExclFunction(unittest.TestCase):
+    def test_single_element_list(self):
+        """
+        Test unlisting a single element list.
+        :return:
+        """
+        data = {'key': ['value']}
+        expected = {'key': 'value'}
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_single_element_nested_list(self):
+        """
+        Test unlisting a single element nested list.
+        :return:
+        """
+        data = {'key': [{'subkey': ['subvalue']}]}
+        expected = {'key': {'subkey': 'subvalue'}}
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_multiple_element_list(self):
+        """
+        Test that a multiple element list is not unlisted.
+        :return:
+        """
+        data = {'key': ['value1', 'value2']}
+        expected = {'key': ['value1', 'value2']}
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_nested_dict_with_single_element_list(self):
+        """
+        Test unlisting a nested dictionary with single element list.
+        :return:
+        """
+        data = {'gene': [{'id': 1017, 'source': ['clinvar']}, {'id': 1018, 'source': ['bg']}]}
+        expected = {'gene': [{'id': 1017, 'source': 'clinvar'}, {'id': 1018, 'source': 'bg'}]}
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_nested_dict_with_multiple_element_list(self):
+        """
+        Test nested dictionary with multiple element list, ensuring no unlisting.
+        :return:
+        """
+        data = {'gene': [{'id': 1017, 'source': ['clinvar', 'dbsnp']}, {'id': 1018, 'source': ['bg']}]}
+        expected = {'gene': [{'id': 1017, 'source': ['clinvar', 'dbsnp']}, {'id': 1018, 'source': 'bg'}]}
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_empty_list(self):
+        """
+        Test that an empty list remains unchanged.
+        :return:
+        """
+        data = {'key': []}
+        expected = {'key': []}
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_no_list(self):
+        """
+        Test that a value without a list remains unchanged.
+        :return:
+        """
+        data = {'key': 'value'}
+        expected = {'key': 'value'}
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_deeply_nested_single_element_list(self):
+        """
+        Test unlisting a deeply nested single element list.
+        :return:
+        """
+        data = {'key': {'subkey': [{'subsubkey': ['subsubvalue']}]} }
+        expected = {'key': {'subkey': {'subsubkey': 'subsubvalue'}} }
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_no_change_needed(self):
+        """
+        Test that no changes are made if no unlisting is needed.
+        :return:
+        """
+        data = {'key': {'subkey': 'subvalue'}}
+        expected = {'key': {'subkey': 'subvalue'}}
+        self.assertEqual(unlist_incexcl(data), expected)
+
+    def test_include_keys_single_element_list(self):
+        """
+        Test unlisting a single element list with include_keys specified.
+        :return:
+        """
+        data = {'key1': ['value1'], 'key2': ['value2']}
+        expected = {'key1': 'value1', 'key2': ['value2']}
+        self.assertEqual(unlist_incexcl(data, include_keys=['key1']), expected)
+
+    def test_include_keys_nested_single_element_list(self):
+        """
+        Test unlisting a nested single element list with include_keys specified.
+        :return:
+        """
+        data = {'key': {'subkey1': ['subvalue1'], 'subkey2': ['subvalue2']}}
+        expected = {'key': {'subkey1': 'subvalue1', 'subkey2': ['subvalue2']}}
+        self.assertEqual(unlist_incexcl(data, include_keys=['key.subkey1']), expected)
+
+    def test_include_keys_no_unlist(self):
+        """
+        Test that no unlisting occurs when include_keys doesn't match the path.
+        :return:
+        """
+        data = {'key1': ['value1'], 'key2': ['value2']}
+        expected = {'key1': ['value1'], 'key2': ['value2']}
+        self.assertEqual(unlist_incexcl(data, include_keys=['key3']), expected)
+
+    def test_exclude_keys_single_element_list(self):
+        """
+        Test unlisting a single element list with exclude_keys specified.
+        :return:
+        """
+        data = {'key1': ['value1'], 'key2': ['value2']}
+        expected = {'key1': 'value1', 'key2': ['value2']}
+        self.assertEqual(unlist_incexcl(data, exclude_keys=['key2']), expected)
+
+    def test_exclude_keys_nested_single_element_list(self):
+        """
+        Test unlisting a nested single element list with exclude_keys specified.
+        :return:
+        """
+        data = {'key': {'subkey1': ['subvalue1'], 'subkey2': ['subvalue2']}}
+        expected = {'key': {'subkey1': ['subvalue1'], 'subkey2': 'subvalue2'}}
+        self.assertEqual(unlist_incexcl(data, exclude_keys=['key.subkey1']), expected)
+
+    def test_exclude_keys_no_unlist(self):
+        """
+        Test that no unlisting occurs when exclude_keys matches the path.
+        :return:
+        """
+        data = {'key1': ['value1'], 'key2': ['value2']}
+        expected = {'key1': ['value1'], 'key2': 'value2'}
+        self.assertEqual(unlist_incexcl(data, exclude_keys=['key1']), expected)
+
+    def test_include_and_exclude_keys(self):
+        """
+        Test both include_keys and exclude_keys are used together.
+        :return:
+        """
+        data = {'key1': ['value1'], 'key2': ['value2'], 'key3': ['value3']}
+        expected = {'key1': 'value1', 'key2': ['value2'], 'key3': ['value3']}
+        self.assertEqual(unlist_incexcl(data, include_keys=['key1', 'key2'], exclude_keys=['key2']), expected)
+
+    def test_exclude_and_include_with_nested_structure(self):
+        """
+        Test both include_keys and exclude_keys are used together in a nested structure.
+        :return:
+        """
+        data = {'key': {'subkey1': ['subvalue1'], 'subkey2': ['subvalue2']}}
+        expected = {'key': {'subkey1': 'subvalue1', 'subkey2': ['subvalue2']}}
+        self.assertEqual(unlist_incexcl(data, include_keys=['key.subkey1'], exclude_keys=['key.subkey2']), expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR improves the `unlist` and `unlist_incexcl` functions to correctly handle deeply nested lists and dictionaries. It ensures that single-element lists are properly unlisted, even within nested structures.

Fixes issue #7 