### PR TITLE
jmespath exclude_empty fix

### DIFF
--- a/biothings/web/query/formatter.py
+++ b/biothings/web/query/formatter.py
@@ -466,7 +466,7 @@ class ESResultFormatter(ResultFormatter):
                 # each item in the obj list has already been transformed during the traversal
                 # in the else block below, so we only need to handle the list itself here
                 if jmespath_exclude_empty:
-                    idx_to_remove = [i for i, _obj in enumerate(obj) if not _obj[target_field]]
+                    idx_to_remove = [i for i, _obj in enumerate(obj) if not _obj.get(target_field)]
                     list_trim(obj, idx_to_remove)   # remove item in-place from obj
                     # if obj is empty, mark the hit to be removed from the hits list
                     # otherwise, we make sure the hit does not have the __exclude__ mark


### PR DESCRIPTION
A KeyError was being raised in the transformation logic whenever a list item did not contain the target_field. In particular, this occurred when making a query to mychem.info with jmespath_exclude_empty=true, causing the transformation step to attempt dictionary access on a missing key.

```
curl --location --globoff 'https://mychem.info/v1/query?size=1000&fields=drugcentral.bioactivity%2Cdrugcentral.xrefs.umlscui%2Cdrugcentral.synonyms&jmespath_exclude_empty=true&always_list=drugcentral.bioactivity&jmespath=drugcentral.bioactivity%7C[%3F!action_type%20%20%26%26%20length(uniprot[%3Funiprot_id%3D%3D%27P29274%27])%20%3E%20%600%60]' \
--header 'Content-Type: application/json' \
--data '{
    "q": ["P29274"],
    "scopes": "drugcentral.bioactivity.uniprot.uniprot_id"
}'
```
This query would raise a KeyError: 'bioactivity' if any list item did not include "bioactivity" as a key.

See https://github.com/biothings/biothings.api/issues/368