### PR TITLE
Remove Deprecated doc_type

### DIFF
--- a/biothings/hub/dataindex/indexer_task.py
+++ b/biothings/hub/dataindex/indexer_task.py
@@ -44,7 +44,6 @@ class ESIndex(BaseESIndex):
         response = self.client.mget(
             body={"ids": ids},
             index=self.index_name,
-            doc_type=self.doc_type,
         )
         for doc in response["docs"]:
             if doc.get("found"):

--- a/biothings/hub/dataindex/indexer_task.py
+++ b/biothings/hub/dataindex/indexer_task.py
@@ -61,7 +61,6 @@ class ESIndex(BaseESIndex):
         """
         res = self.client.search(
             index=self.index_name,
-            doc_type=self.doc_type,
             body={"query": {"ids": {"values": ids}}},
             stored_fields=None,
             _source=None,


### PR DESCRIPTION
The `doc_type` was deprecated in Elasticsearch 7.x.

It was removed entirely in Elasticsearch 8.x and the corresponding Python client.