### PR TITLE
Various bugfixes and cleanup

### DIFF
--- a/biothings/cli/dataplugin.py
+++ b/biothings/cli/dataplugin.py
@@ -287,7 +287,6 @@ def index_plugin(
 @dataplugin_application.command(name="validate")
 def validate_manifest(
     plugin_name: Annotated[str, typer.Option("--plugin-name", help="Data source plugin name")] = None,
-    manifest_file: Annotated[str, typer.Option("--manifest-file", "-m", help="Data source manifest file")] = None,
     show_schema: Annotated[bool, typer.Option("--show-schema", help="Display biothings manifest schema")] = None,
 ) -> None:
     """
@@ -307,6 +306,6 @@ def validate_manifest(
     For a reference about jsonschema itself, see the following:
     https://json-schema.org/
     """
-    asyncio.run(operations.validate_manifest(plugin_name=plugin_name, manifest_file=manifest_file))
+    asyncio.run(operations.validate_manifest(plugin_name=plugin_name))
     if show_schema:
         asyncio.run(operations.display_schema())

--- a/biothings/cli/dataplugin.py
+++ b/biothings/cli/dataplugin.py
@@ -286,7 +286,7 @@ def index_plugin(
 
 @dataplugin_application.command(name="validate")
 def validate_manifest(
-    plugin_name: Annotated[str, typer.Option("--plugin", help="Data source plugin name")] = None,
+    plugin_name: Annotated[str, typer.Option("--plugin-name", help="Data source plugin name")] = None,
     manifest_file: Annotated[str, typer.Option("--manifest-file", "-m", help="Data source manifest file")] = None,
     show_schema: Annotated[bool, typer.Option("--show-schema", help="Display biothings manifest schema")] = None,
 ) -> None:

--- a/biothings/cli/operations.py
+++ b/biothings/cli/operations.py
@@ -186,7 +186,16 @@ async def do_dump(plugin_name: str = None, show_dumped: bool = True) -> None:
 
     if dumper_instance.need_prepare():
         dumper_instance.prepare()
+
+    try:
         dumper_instance.set_release()
+    except AttributeError:
+        attribute_warning = (
+            "Unable to call `set_release` for dumper instance [%s]. "
+            "This is likely because the dumper instance does not support this method",
+            dumper_instance,
+        )
+        logger.warning(attribute_warning)
 
     dump_job = dumper_instance.dump(
         job_manager=assistant_instance.job_manager,

--- a/biothings/cli/operations.py
+++ b/biothings/cli/operations.py
@@ -123,7 +123,10 @@ def operation_mode(operation_method: Callable):
             logger.debug("Inferring multiple plugins from directory structure")
             mode = "HUB"
 
-        if mode == "HUB":
+        if mode == "SINGULAR":
+            if kwargs.get("plugin_name", None) is not None:
+                kwargs["plugin_name"] = None
+        elif mode == "HUB":
             if kwargs.get("plugin_name", None) is None:
                 raise MissingPluginName(working_directory)
 
@@ -539,7 +542,6 @@ async def do_clean(plugin_name: str = None, dump: bool = False, upload: bool = F
         clean_uploaded_sources(assistant_instance.plugin_directory, assistant_instance.plugin_name)
 
 
-@operation_mode
 async def display_schema():
     """
     Loads the jsonschema definition file and displays it to the
@@ -572,24 +574,21 @@ async def display_schema():
 
 
 @operation_mode
-async def validate_manifest(plugin_name: str = None, manifest_file: Union[str, pathlib.Path] = None):
+async def validate_manifest(plugin_name: str = None):
     """
     Loads the manifest file and validates it against the schema file
     If an error exists it will display the error to the enduser
     """
     from biothings.hub.dataplugin.loaders.loader import ManifestBasedPluginLoader
 
-    if plugin_name is None and manifest_file is None:
-        plugin_directory = pathlib.Path.cwd()
+    if plugin_name is None:
+        plugin_directory = pathlib.Path.cwd().resolve().absolute()
         plugin_name = plugin_directory.name
         manifest_file = plugin_directory.joinpath("manifest.json")
-    elif plugin_name is not None and manifest_file is None:
-        plugin_directory = pathlib.Path.cwd()
-        plugin_name = plugin_directory.name
+    else:
+        calling_directory = pathlib.Path.cwd().resolve().absolute()
+        plugin_directory = calling_directory.joinpath(plugin_name)
         manifest_file = plugin_directory.joinpath("manifest.json")
-    elif plugin_name is None and manifest_file is not None:
-        manifest_file = pathlib.Path(manifest_file).resolve().absolute()
-        plugin_name = manifest_file.parent.name
 
     manifest_loader = ManifestBasedPluginLoader(plugin_name=plugin_name)
     manifest_state = {"path": manifest_file, "valid": False, "repr": None, "error": None}

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -880,7 +880,8 @@ class HTTPDumper(BaseDumper):
 
 
 class LastModifiedHTTPDumper(HTTPDumper, LastModifiedBaseDumper):
-    """Given a list of URLs, check Last-Modified header to see
+    """
+    Given a list of URLs, check Last-Modified header to see
     whether the file should be downloaded. Sub-class should only have
     to declare SRC_URLS. Optionally, another field name can be used instead
     of Last-Modified, but date format must follow RFC 2616. If that header
@@ -897,11 +898,11 @@ class LastModifiedHTTPDumper(HTTPDumper, LastModifiedBaseDumper):
     # with a list of URLs only, without any information
     # about the local filename to store data in
 
-    def remote_is_better(self, remotefile, localfile):
+    def remote_is_better(self, remotefile, localfile) -> bool:
         res = self.client.head(remotefile, allow_redirects=True)
         if self.__class__.LAST_MODIFIED not in res.headers:
             self.logger.warning(
-                "Header '%s' doesn't exist, can determine if remote is better, assuming it is..."
+                "Header '%s' doesn't exist, defaulting to re-downloading the remote data ..."
                 % self.__class__.LAST_MODIFIED
             )
             return True

--- a/biothings/utils/sqlite3.py
+++ b/biothings/utils/sqlite3.py
@@ -388,7 +388,7 @@ class Collection:
         logger.debug('SQLite query: "%s"', _query)
         results = (json_loads(doc[0]) for doc in conn.execute(_query))  # results is a generator
         if return_list:
-            results = List(results)
+            results = list(results)
         if return_total:
             # get total count without limit and offset
             total = conn.execute(query.replace("SELECT document FROM", "SELECT COUNT(*) FROM")).fetchone()[0]
@@ -501,7 +501,7 @@ class Collection:
             except sqlite3.IntegrityError as integrity_err:
                 logger.exception(integrity_err)
                 id_counter = collections.Counter([doc["_id"] for doc in rendered_documents])
-                discovered_non_unique_id = List(
+                discovered_non_unique_id = list(
                     filter(lambda id_frequency: id_frequency[1] > 1, id_counter.most_common(10))
                 )
                 if len(discovered_non_unique_id) > 0:


### PR DESCRIPTION
- Remove the `List` type for `list` data structure calls
- Add exception handling for the command-line dumper `set_release` function call
- Fix the manifest validation plugin path determination
- Improve the warning message for `LastModifiedHTTPDumper` remote determination function