### PR TITLE
Isolate cli job management

### DIFF
--- a/biothings/cli/assistant.py
+++ b/biothings/cli/assistant.py
@@ -16,7 +16,6 @@ Supported plugin locations
 import asyncio
 import copy
 import logging
-import os
 import pathlib
 import sys
 
@@ -25,7 +24,8 @@ import typer
 
 from biothings.utils.common import get_plugin_name_from_local_manifest
 from biothings.hub.dataplugin.assistant import BaseAssistant
-from biothings.utils.manager import JobManager
+
+from biothings.cli.manager import CLIJobManager
 
 logger = logging.getLogger(name="biothings-cli")
 
@@ -65,15 +65,7 @@ class CLIAssistant(BaseAssistant):
         url = f"local://{plugin_name}"
         super().__init__(url, plugin_name, src_folder)
 
-        self.job_manager = JobManager(
-            loop=asyncio.get_running_loop(),
-            process_queue=None,
-            thread_queue=None,
-            max_memory_usage=None,
-            num_workers=os.cpu_count(),
-            num_threads=16,
-            auto_recycle=True,
-        )
+        self.job_manager = CLIJobManager(loop=asyncio.get_running_loop())
         self.dumper_manager = DumperManager(job_manager=self.job_manager, datasource_path=self.data_directory)
         self.uploader_manager = UploaderManager(job_manager=self.job_manager, datasource_path=self.data_directory)
         self.data_plugin_manager = DataPluginManager(job_manager=self.job_manager, datasource_path=self.data_directory)

--- a/biothings/cli/assistant.py
+++ b/biothings/cli/assistant.py
@@ -38,7 +38,7 @@ class CLIAssistant(BaseAssistant):
 
     plugin_type = "CLI"
 
-    def __init__(self, plugin_name: str = None):
+    def __init__(self, plugin_name: str = None, job_manager: "JobManager" = None):
         from biothings import config
 
         from biothings.hub.databuild.builder import BuilderManager
@@ -65,7 +65,10 @@ class CLIAssistant(BaseAssistant):
         url = f"local://{plugin_name}"
         super().__init__(url, plugin_name, src_folder)
 
-        self.job_manager = CLIJobManager(loop=asyncio.get_running_loop())
+        if job_manager is None:
+            job_manager = CLIJobManager(loop=asyncio.get_running_loop())
+        self.job_manager = job_manager
+
         self.dumper_manager = DumperManager(job_manager=self.job_manager, datasource_path=self.data_directory)
         self.uploader_manager = UploaderManager(job_manager=self.job_manager, datasource_path=self.data_directory)
         self.data_plugin_manager = DataPluginManager(job_manager=self.job_manager, datasource_path=self.data_directory)

--- a/biothings/cli/dataplugin.py
+++ b/biothings/cli/dataplugin.py
@@ -268,7 +268,10 @@ def clean_data(
 
 @dataplugin_application.command(name="index")
 def index_plugin(
-    plugin_name: Annotated[str, typer.Option("--plugin", help="Data source plugin name")] = None,
+    plugin_name: Annotated[str, typer.Option("--plugin-name", "-n", help="Provide a data source plugin name")] = None,
+    sub_source_name: Annotated[
+        Optional[str], typer.Option("--sub-source-name", "-s", help="Provide a data sub-source plugin name")
+    ] = None,
 ):
     """
     [red][bold](experimental)[/bold][/red] Create an elaticsearch index from a data source database
@@ -281,7 +284,7 @@ def index_plugin(
     [green]NOTE[/green]
     Only works correctly if the upload command has been run
     """
-    asyncio.run(operations.do_index(plugin_name=plugin_name))
+    asyncio.run(operations.do_index(plugin_name=plugin_name, sub_source_name=sub_source_name))
 
 
 @dataplugin_application.command(name="validate")

--- a/biothings/cli/dataplugin.py
+++ b/biothings/cli/dataplugin.py
@@ -167,7 +167,7 @@ def inspect_source(
         Optional[bool],
         typer.Option(
             "--merge",
-            "-m",
+            "-g",
             help="""Merge scalar into list when both exist (eg. {"val":..} and [{"val":...}])""",
         ),
     ] = False,

--- a/biothings/cli/exceptions.py
+++ b/biothings/cli/exceptions.py
@@ -17,3 +17,15 @@ class MissingPluginName(Exception):
             "or change your directory upon execution"
         )
         super().__init__(message)
+
+
+class UnknownUploaderSource(Exception):
+    """
+    Used in the elasticsearch indexing
+
+    If no elasticsearch mapping is found for a plugin and multiple
+    data sources have been uploaded, we have to specify via --sub-source-name
+    what specific uploaded data source we wish to index. If that
+    subsource name doesn't match any of the uploaded sources discovered
+    by the uploader manager, then we raise this exception
+    """

--- a/biothings/cli/manager.py
+++ b/biothings/cli/manager.py
@@ -1,0 +1,38 @@
+"""
+Temporary stopgap to leverage this minimal instance
+due to our limitation in the multiprocessing starting
+method
+
+Once we support setting new processes to spawn instead of fork,
+we can eliminate this manager
+"""
+
+from biothings.utils.common import get_loop
+
+
+class CLIJobManager:
+    """This is the minimal JobManager used in CLI mode to run async jobs, with the compatible methods as JobManager.
+    It won't use a dedicated ProcessPool or ThreadPool, and will just run async job directly in the asyncio loop
+    (which runs jobs in threads by default).
+    """
+
+    def __init__(self, loop=None):
+        self.loop = loop or get_loop()
+
+    async def defer_to_process(self, pinfo=None, func=None, *args, **kwargs):
+        """keep the same signature as JobManager.defer_to_process. The passed pinfo is ignored.
+        defer_to_process will still run func in the thread using defer_to_thread method.
+        """
+        fut = await self.defer_to_thread(pinfo, func, *args, **kwargs)
+        return fut
+
+    async def defer_to_thread(self, pinfo=None, func=None, *args):
+        """keep the same signature as JobManager.defer_to_thread. The passed pinfo is ignored"""
+
+        async def run(fut, func):
+            res = func()
+            fut.set_result(res)
+
+        fut = self.loop.create_future()
+        self.loop.create_task(run(fut, func))
+        return fut

--- a/biothings/cli/operations.py
+++ b/biothings/cli/operations.py
@@ -512,8 +512,8 @@ async def do_index(plugin_name: str, sub_source_name: str = None) -> None:
 
         if not discovered_source_uploader:
             missing_source_uploader_message = (
-                f"Unable to find the source uploader corresponding to {sources[0]}. "
-                f"Discovered the following uploaders from plugin manager: {discovered_sources}"
+                f"Unable to find the source uploader corresponding to {sources[0]}.\n"
+                f"\t>>> Discovered the following uploaders from plugin manager: {valid_sources}"
             )
             raise UnknownUploaderSource(missing_source_uploader_message) from build_exc
 

--- a/biothings/cli/operations.py
+++ b/biothings/cli/operations.py
@@ -267,7 +267,7 @@ async def do_upload(plugin_name: str = None, batch_limit: int = 10000, show_uplo
         uploader.keep_archive = 3  # keep 3 archived collections, that's probably good enough for CLI, default is 10
         uploader.clean_archived_collections()
 
-        document_count = uploader.db[uploader.temp_collection_name].count()
+        document_count = uploader.db[uploader.collection_name].count()
         uploader.register_status("success", count=document_count, err=None, tb=None)
 
     if show_uploaded:
@@ -419,6 +419,14 @@ async def do_index(plugin_name: str, sub_source_name: str = None) -> None:
 
     if platform.system() == "Windows":
         logger.warning("The `biothings-cli dataplugin index` command isn't supported on windows")
+        raise typer.Exit(code=2)
+
+    if config.HUB_DB_BACKEND["module"] == "biothings.utils.sqlite3":
+        logger.warning(
+            "The `biothings-cli dataplugin index` command only supports MongoDB as the HUB_DB_BACKEND. "
+            "Please setup MongoDB locally and change the configuration to use the following to continue: \n%s",
+            json.dumps({"module": "biothings.utils.mongo", "uri": "mongodb://localhost:27017"}, indent=4),
+        )
         raise typer.Exit(code=2)
 
     logger.debug('Forcing the multiprocessing start method to "fork"')

--- a/biothings/cli/operations.py
+++ b/biothings/cli/operations.py
@@ -16,6 +16,10 @@ Grouped into the following categories
 > async def do_parallel_upload
 > async def do_dump_and_upload
 > async def do_list
+
+--------------------------------------------------------------------------------
+### data build / index ###
+--------------------------------------------------------------------------------
 > async def do_index
 
 ------------------------------------------------------------------------------------
@@ -47,8 +51,11 @@ import asyncio
 import functools
 import json
 import logging
+import multiprocessing
 import os
+import platform
 import pathlib
+import random
 import shutil
 import sys
 import uuid
@@ -75,7 +82,7 @@ from biothings.cli.utils import (
     write_mapping_to_file,
 )
 from biothings.utils.workers import upload_worker
-from biothings.cli.exceptions import MissingPluginName
+from biothings.cli.exceptions import MissingPluginName, UnknownUploaderSource
 
 logger = logging.getLogger(name="biothings-cli")
 
@@ -232,6 +239,7 @@ async def do_upload(plugin_name: str = None, batch_limit: int = 10000, show_uplo
     uploader_classes = assistant_instance.get_uploader_class()
     for uploader_class in uploader_classes:
         uploader = uploader_class.create(db_conn_info="")
+        uploader.register_status("uploading")
         uploader.make_temp_collection()
         uploader.prepare_src_dump()
         uploader.prepare()
@@ -259,8 +267,11 @@ async def do_upload(plugin_name: str = None, batch_limit: int = 10000, show_uplo
         uploader.keep_archive = 3  # keep 3 archived collections, that's probably good enough for CLI, default is 10
         uploader.clean_archived_collections()
 
+        document_count = uploader.db[uploader.temp_collection_name].count()
+        uploader.register_status("success", count=document_count, err=None, tb=None)
+
     if show_uploaded:
-        logger.info("[green]Success![/green] :rocket:", extra={"markup": True})
+        logger.info("[green]Success![/green] :rocket:", extra={"markup": True, "notify": True})
         show_uploaded_sources(pathlib.Path(assistant_instance.plugin_directory), assistant_instance.plugin_name)
 
 
@@ -391,11 +402,27 @@ async def do_index(plugin_name: str, sub_source_name: str = None) -> None:
     that provide the elasticsearch mapping and a split that do not. If a hardcoded mapping
     is not provided, then we attempt to provide a mapping dynamically through our inspection
     operation
+
+    3) We then create a build through the merge operation. Due to limitations and the fact that the
+    command-line we meant to examine a singular source at a time, it's limited to a LinkDataBuilder
+    as we aren't merging multiple data sources together and have a singular datasource in the build
+
+    4) Lastly is actually creating the new elasticsearch index from the build. This does require
+    elasticsearch to be running at the specified address in the settings.py file or configuration.
+    The default location is localhost:9200. If successful a couple frames detailing the build and
+    index information will be displayed to the enduser
     """
     from biothings import config
     from biothings.utils.manager import JobManager
     from biothings.cli.assistant import CLIAssistant
     from biothings.hub.databuild.builder import BuilderException
+
+    if platform.system() == "Windows":
+        logger.warning("The `biothings-cli dataplugin index` command isn't supported on windows")
+        raise typer.Exit(code=2)
+
+    logger.debug('Forcing the multiprocessing start method to "fork"')
+    multiprocessing.set_start_method("fork")
 
     index_job_manager = JobManager(
         loop=asyncio.get_running_loop(),
@@ -409,6 +436,23 @@ async def do_index(plugin_name: str, sub_source_name: str = None) -> None:
 
     assistant_instance = CLIAssistant(plugin_name, job_manager=index_job_manager)
     assistant_instance.build_manager.configure()
+    uploader_manager = assistant_instance.uploader_manager
+
+    valid_sources = [uploader.name for uploader in uploader_manager[assistant_instance.plugin_name]]
+    if len(valid_sources) > 1 and sub_source_name is None or sub_source_name not in valid_sources:
+        logger.error(
+            (
+                "Multiple uploaders exist for %s data-plugin, so --sub-source-name (-s) "
+                "must be provided to specify which source you want to index.\n"
+                "\t>>> Supported values for --sub-source-name: %s\n"
+                "\t>>> Example: `biothings-cli dataplugin index --plugin-name %s --sub-source-name %s"
+            ),
+            assistant_instance.plugin_name,
+            valid_sources,
+            assistant_instance.plugin_name,
+            random.choice(valid_sources),
+        )
+        raise typer.Exit(code=2)
 
     plugin_identifier = uuid.uuid4()
     build_configuration_name = f"{assistant_instance.plugin_name}-{plugin_identifier}-configuration"
@@ -430,26 +474,13 @@ async def do_index(plugin_name: str, sub_source_name: str = None) -> None:
         builder_class=builder_class,
         params=build_config_params,
     )
-    data_builder = assistant_instance.build_manager[build_configuration_name]
 
     # validate available sources before continuing
     data_builder = assistant_instance.build_manager[build_configuration_name]
-    master_documents = set(data_builder.source_backend.get_src_master_docs())
-
-    if len(set(sources) & master_documents) == 0:
-        logger.error(
-            "%s sources not found in the source master documents. "
-            "If multiple data sources exist for the plugin, `--sub-source-name` may be required. "
-            "Discovered sources from source backend master documents %s",
-            sources,
-            master_documents,
-        )
-        raise typer.Exit(code=1)
-
     elasticsearch_mapping = None
     try:
         elasticsearch_mapping = data_builder.get_mapping(sources)
-    except BuilderException:
+    except BuilderException as build_exc:
         logger.info("No registered mapping found. Auto-generating mapping for source(s) %s", sources)
         generated_mapping = process_inspect(
             source_name=sources[0],
@@ -459,14 +490,24 @@ async def do_index(plugin_name: str, sub_source_name: str = None) -> None:
         )
         elasticsearch_mapping = generated_mapping["results"]["mapping"]
 
-        uploader_manager = assistant_instance.uploader_manager
-        uploader_class = uploader_manager.register[assistant_instance.plugin_name][0]
-        plugin_uploader = uploader_class(db_conn_info="")
-        plugin_uploader.prepare()
-        plugin_uploader.update_master()
-        master_document = plugin_uploader.generate_doc_src_master()
-        master_document["mapping"] = elasticsearch_mapping
-        plugin_uploader.save_doc_src_master(master_document)
+        discovered_source_uploader = False
+        for uploader_class in uploader_manager[assistant_instance.plugin_name]:
+            if uploader_class.name == sources[0]:
+                plugin_uploader = uploader_class(db_conn_info="")
+                plugin_uploader.prepare()
+                plugin_uploader.update_master()
+                master_document = plugin_uploader.generate_doc_src_master()
+                master_document["mapping"] = elasticsearch_mapping
+                plugin_uploader.save_doc_src_master(master_document)
+                discovered_source_uploader = True
+                break
+
+        if not discovered_source_uploader:
+            missing_source_uploader_message = (
+                f"Unable to find the source uploader corresponding to {sources[0]}. "
+                f"Discovered the following uploaders from plugin manager: {discovered_sources}"
+            )
+            raise UnknownUploaderSource(missing_source_uploader_message) from build_exc
 
     # create a temporary build
     merge_job = assistant_instance.build_manager.merge(
@@ -531,25 +572,30 @@ async def do_inspect(
 
     assistant_instance = CLIAssistant(plugin_name)
     uploader_classes = assistant_instance.get_uploader_class()
-    if len(uploader_classes) > 1:
-        if not sub_source_name:
-            logger.error(
-                (
-                    'This is a multiple uploaders data plugin, so "--sub-source-name" must be provided! '
-                    'Accepted values of "--sub-source-name" are: %s'
-                ),
-                ", ".join(uploader.name for uploader in uploader_classes),
-            )
-            raise typer.Exit(code=1)
-        logger.info(
-            'Inspecting data plugin "%s" (sub_source_name="%s", mode="%s", limit=%s)',
+
+    valid_sources = [uploader.name for uploader in uploader_classes]
+    if len(valid_sources) > 1 and sub_source_name is None or sub_source_name not in valid_sources:
+        logger.error(
+            (
+                "Multiple uploaders exist for %s data-plugin, so --sub-source-name (-s) "
+                "must be provided to specify which source you want to inspect.\n"
+                "\t>>> Supported values for --sub-source-name: %s\n"
+                "\t>>> Example: `biothings-cli dataplugin inspect --plugin-name %s --sub-source-name %s"
+            ),
             assistant_instance.plugin_name,
-            sub_source_name,
-            mode,
-            limit,
+            valid_sources,
+            assistant_instance.plugin_name,
+            random.choice(valid_sources),
         )
-    else:
-        logger.info('Inspecting data plugin "%s" (mode="%s", limit=%s)', assistant_instance.plugin_name, mode, limit)
+        raise typer.Exit(code=2)
+
+    logger.info(
+        'Inspecting data plugin "%s" (sub_source_name="%s", mode="%s", limit=%s)',
+        assistant_instance.plugin_name,
+        sub_source_name,
+        mode,
+        limit,
+    )
 
     table_space = [item.name for item in uploader_classes]
     if sub_source_name and sub_source_name not in table_space:


### PR DESCRIPTION
Revert back to leveraging the simplified `CLIJobManager` for most cases. Until we can refactor our configuration environment to work with parallel jobs, we'll leverage this manager for compatibility.   