### PR TITLE
Remove deprecated elasticsearch_dsl

### DIFF
--- a/biothings/web/connections.py
+++ b/biothings/web/connections.py
@@ -5,7 +5,6 @@ import pickle
 from functools import partial
 
 import elasticsearch
-import elasticsearch_dsl
 import requests
 from tornado.ioloop import IOLoop
 
@@ -27,7 +26,10 @@ _should_log = run_once()
 
 def _log_pkg():
     es_ver = elasticsearch.__version__
-    es_dsl_ver = elasticsearch_dsl.__versionstr__
+
+    # since v8.18.0, the DSL is released as part of the main elasticsearch package.
+    # dsl version is therefore aligned with base es version
+    es_dsl_ver = es_ver
 
     logger.info("Elasticsearch Package Version: %s", ".".join(map(str, es_ver)))
     logger.info("Elasticsearch DSL Package Version: %s", ".".join(map(str, es_dsl_ver)))

--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -38,8 +38,8 @@ import os
 import re
 from typing import Iterable, List, Set, Tuple, Union
 
-from elasticsearch_dsl import MultiSearch, Q, Search
-from elasticsearch_dsl.exceptions import IllegalOperation
+from elasticsearch.dsl import MultiSearch, Q, Search
+from elasticsearch.dsl.exceptions import IllegalOperation
 import orjson
 
 from biothings.utils.common import dotdict

--- a/biothings/web/query/engine.py
+++ b/biothings/web/query/engine.py
@@ -11,7 +11,7 @@ Example:
 
 >>> from biothings.web.query import ESQueryBackend
 >>> from elasticsearch import Elasticsearch
->>> from elasticsearch_dsl import Search
+>>> from elasticsearch.dsl import Search
 
 >>> backend = ESQueryBackend(Elasticsearch())
 >>> backend.execute(Search().query("match", _id="1017"))
@@ -24,7 +24,7 @@ dict_keys(['taxid', 'symbol', 'name', ... ])
 import asyncio
 
 from elasticsearch import NotFoundError, RequestError
-from elasticsearch_dsl import MultiSearch, Search
+from elasticsearch.dsl import MultiSearch, Search
 
 from biothings.web.query.builder import ESScrollID
 

--- a/docs/tutorial/web.rst
+++ b/docs/tutorial/web.rst
@@ -295,7 +295,7 @@ with a few rules to increase result relevancy. Additionally add to the ``pipelin
 .. code-block:: python
 
     from biothings.web.query import ESQueryBuilder 
-    from elasticsearch_dsl import Search
+    from elasticsearch.dsl import Search
 
     class MyQueryBuilder(ESQueryBuilder):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,7 @@ dependencies = [
     'tornado==6.4.2; python_version >= "3.8.0"',
     "gitpython>=3.1.0",
     "elasticsearch[async]>=7, <8; python_version < '3.7.0'",
-    "elasticsearch-dsl>=7, <8; python_version < '3.7.0'",
     "elasticsearch[async]>=8, <9; python_version >= '3.7.0'",
-    "elasticsearch-dsl>=8, <9; python_version >= '3.7.0'",
     'singledispatchmethod; python_version < "3.8.0"',
     'dataclasses; python_version < "3.7.0"',
     "jmespath>=0.7.1,<2.0.0",  # support jmespath query parameter


### PR DESCRIPTION
Resolve #398

- Removed `elasticsearch_dsl` as a separate dependency
- Replaced all imports from `elasticsearch_dsl` with `elasticsearch.dsl`
- Updated version detection logic as DSL version now aligns with the base `elasticsearch` package

Note:This change introduces a breaking change for environments using `Python < 3.8`, where `elasticsearch_dsl` is still required as a separate dependency. However, this is not considered an issue for the upcoming `biothings 1.1.x` release, as support for `Python <= 3.8` will be officially dropped.