### PR TITLE
Improve handler missing name.

### DIFF
--- a/biothings/web/handlers/base.py
+++ b/biothings/web/handlers/base.py
@@ -129,13 +129,10 @@ class BaseAPIHandler(BaseHandler, AnalyticsMixin):
 
             if handler_has_kwargs:
                 # Handler defines kwargs but uses default name - this will cause conflicts
-                raise HTTPError(
-                    500,
-                    reason=(
-                        f"Handler {self.__class__.__name__} defines 'kwargs' but doesn't define "
-                        f"a unique 'name' attribute. This causes parameter validation conflicts. "
-                        f"Please add: name = 'your_handler_name' to the class definition."
-                    )
+                raise ValueError(
+                    f"Handler {self.__class__.__name__} defines 'kwargs' but doesn't define "
+                    f"a unique 'name' attribute. This causes parameter validation conflicts. "
+                    f"Please add: name = 'your_handler_name' to the class definition."
                 )
             else:
                 # Handler doesn't define kwargs and doesn't define name - this is ok

--- a/biothings/web/handlers/base.py
+++ b/biothings/web/handlers/base.py
@@ -145,9 +145,6 @@ class BaseAPIHandler(BaseHandler, AnalyticsMixin):
         optionsets = self.biothings.optionsets
         optionset = optionsets.get(self.name)
 
-        # Initialize args variable for the finally block
-        args = None
-
         try:  # uses biothings.web.options to standardize args
             args = optionset.parse(self.request.method, reqargs)
 


### PR DESCRIPTION
# Issue
Endpoint parameter validation issue. There is a kwargs conflict when a new handler class is created and it doesn't have the attribute `name` but has the `kwargs`. This causes parameter validation conflicts. 

# Solution
Raise an exception asking to add the attribute `name` to the class definition if a `kwargs` is set.

# Client log error example
```
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: tornado.web.HTTPError: HTTP 400: Bad Request
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: WARNING:tornado.access:400 GET /user (192.42.82.57) 1.57ms
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: DEBUG:biothings.web.handlers.base:Event({})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: DEBUG:biothings.web.handlers.base:GET /user
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: ReqArgs()
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: OptionError({'missing': 'url'})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: DEBUG:biothings.web.handlers.base:
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: Traceback (most recent call last):
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 127, in _parse_args
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     args = optionset.parse(self.request.method, reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 707, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise err  # with helpful info
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     ^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 702, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     val = option.parse(reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:           ^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 634, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     val = self._exists.inquire(val)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:           ^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 466, in inquire
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise OptionError(
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: biothings.web.options.manager.OptionError: OptionError({'missing': 'url'})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: During handling of the above exception, another exception occurred:
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: Traceback (most recent call last):
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/tornado/web.py", line 1767, in _execute
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     result = self.prepare()
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:              ^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 95, in prepare
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     self.args = self._parse_args(reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 131, in _parse_args
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise HTTPError(400, None, err.info)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: tornado.web.HTTPError: HTTP 400: Bad Request
```

# Here is the raised exception after this change
```
{
  "code": 500,
  "success": false,
  "error": "Internal Server Error",
  "details": "Handler HandlerClass defines 'kwargs' but doesn't define a unique 'name' attribute. This causes parameter validation conflicts. Please add: name = 'your_handler_name' to the class definition."
}
```