### PR TITLE
Fix handler missing name.

### DIFF
--- a/biothings/web/handlers/base.py
+++ b/biothings/web/handlers/base.py
@@ -94,7 +94,13 @@ class BaseAPIHandler(BaseHandler, AnalyticsMixin):
         )
         # standardized request arguments
         self.args = self._parse_args(reqargs)
-        self.format = self.args.format
+
+        # Handle cases where args is a plain dict (e.g., when name is missing or None)
+        if hasattr(self.args, 'format'):
+            self.format = self.args.format
+        else:
+            # Use the default format when args doesn't have format attribute
+            self.format = "json"
 
     def _parse_json(self):
         if not self.request.body:
@@ -113,6 +119,26 @@ class BaseAPIHandler(BaseHandler, AnalyticsMixin):
     def _parse_args(self, reqargs):
         if not self.name:  # feature disabled
             return {}  # default value
+
+        # Check if handler defines kwargs but not a unique name - this is an error
+        if self.name == "__base__" and self.__class__ != BaseAPIHandler:
+            # Check if this handler defines its own kwargs (not inherited from BaseAPIHandler)
+            handler_has_kwargs = (
+                hasattr(self.__class__, 'kwargs') and
+                self.__class__.kwargs is not BaseAPIHandler.kwargs
+            )
+
+            if handler_has_kwargs:
+                # Handler defines kwargs but uses default name - this will cause conflicts
+                raise ValueError(
+                    f"Handler {self.__class__.__name__} defines 'kwargs' but doesn't define "
+                    f"a unique 'name' attribute. This causes parameter validation conflicts. "
+                    f"Please add: name = 'your_handler_name' to the class definition."
+                )
+            else:
+                # Handler doesn't define kwargs and doesn't define name - this is ok
+                # Return empty args to disable parameter validation
+                return {}
 
         optionsets = self.biothings.optionsets
         optionset = optionsets.get(self.name)


### PR DESCRIPTION
# Issue
Endpoint parameter validation issue. There is a kwargs conflict when a new handler class is created and it doesn't have the attribute `name` but has the `kwargs`. This causes parameter validation conflicts. 

# Solution
Raise an exception asking to add the attribute `name` to the class definition if a `kwargs` is set.

# Client log error example
```
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: tornado.web.HTTPError: HTTP 400: Bad Request
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: WARNING:tornado.access:400 GET /user (192.42.82.57) 1.57ms
Aug 05 10:30:13 ip-172-40-40-110 python[1060666]: DEBUG:biothings.web.handlers.base:Event({})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: DEBUG:biothings.web.handlers.base:GET /user
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: ReqArgs()
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: OptionError({'missing': 'url'})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: DEBUG:biothings.web.handlers.base:
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: Traceback (most recent call last):
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 127, in _parse_args
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     args = optionset.parse(self.request.method, reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 707, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise err  # with helpful info
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     ^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 702, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     val = option.parse(reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:           ^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 634, in parse
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     val = self._exists.inquire(val)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:           ^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/options/manager.py", line 466, in inquire
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise OptionError(
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: biothings.web.options.manager.OptionError: OptionError({'missing': 'url'})
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: During handling of the above exception, another exception occurred:
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: Traceback (most recent call last):
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/tornado/web.py", line 1767, in _execute
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     result = self.prepare()
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:              ^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 95, in prepare
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     self.args = self._parse_args(reqargs)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:   File "/home/ubuntu/smartapi/.env/lib/python3.12/site-packages/biothings/web/handlers/base.py", line 131, in _parse_args
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]:     raise HTTPError(400, None, err.info)
Aug 05 10:30:13 ip-172-40-40-110 python[1060648]: tornado.web.HTTPError: HTTP 400: Bad Request
```

# Here is the raised exception after this change
```
{
  "code": 500,
  "success": false,
  "error": "Internal Server Error",
  "details": "Handler HandlerClass defines 'kwargs' but doesn't define a unique 'name' attribute. This causes parameter validation conflicts. Please add: name = 'your_handler_name' to the class definition."
}
```