### PR TITLE
Bulk Indexing Error Improvement

### DIFF
--- a/biothings/hub/dataindex/indexer_task.py
+++ b/biothings/hub/dataindex/indexer_task.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from collections import namedtuple
 from enum import Enum
@@ -10,6 +9,7 @@ from pymongo import MongoClient
 
 from biothings.utils.es import ESIndex as BaseESIndex
 from biothings.utils.loggers import get_logger
+from biothings.utils.serializer import to_json
 
 try:
     from biothings.utils.mongo import doc_feeder
@@ -93,7 +93,7 @@ class ESIndex(BaseESIndex):
                 self.logger.error(error)
                 self.logger.error("Document ID %s failed: %s", document_id, reason)
 
-            serialized_errors = json.dumps(errors, indent=2, default=str)
+            serialized_errors = to_json(errors, indent=True)
             message = (
                 f"Bulk indexing failed for index '{self.index_name}'. "
                 f"Elasticsearch responded with errors:\n{serialized_errors}"

--- a/biothings/hub/dataindex/indexer_task.py
+++ b/biothings/hub/dataindex/indexer_task.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections import namedtuple
 from enum import Enum
@@ -92,8 +93,12 @@ class ESIndex(BaseESIndex):
                 self.logger.error(error)
                 self.logger.error("Document ID %s failed: %s", document_id, reason)
 
-            self.logger.warning("Discovered errors during the bulk index task. Defaulting to 0 indexed documents")
-            return 0
+            serialized_errors = json.dumps(errors, indent=2, default=str)
+            message = (
+                f"Bulk indexing failed for index '{self.index_name}'. "
+                f"Elasticsearch responded with errors:\n{serialized_errors}"
+            )
+            raise helpers.BulkIndexError(message, errors) from e
 
     # NOTE
     # Why doesn't "mget", "mexists", "mindex" belong to the base class?


### PR DESCRIPTION
Instead of silently returning zero indexed documents when bulk indexing fails, the code now raises a detailed exception that includes serialized error information. 

**Error handling and logging improvements:**

* When bulk indexing fails, the code now serializes the error details using the `to_json` utility and raises a `BulkIndexError` with a descriptive message, instead of returning 0 and logging a warning.