### PR TITLE
Fix a JobManager issue specific to Python 3.14

### DIFF
--- a/biothings/utils/manager.py
+++ b/biothings/utils/manager.py
@@ -3,8 +3,10 @@ import concurrent.futures
 import copy
 import datetime
 import glob
+import multiprocessing
 import os
 import re
+import sys
 import threading
 import time
 import types
@@ -166,6 +168,15 @@ class JobManager:
     HEADERLINE = "{pid:^10}|{source:^35}|{category:^10}|{step:^20}|{description:^30}|{mem:^10}|{cpu:^6}|{started_at:^20}|{duration:^10}"
     DATALINE = HEADERLINE.replace("^", "<")
 
+    def _get_process_executor(self):
+        kwargs = {}
+        if sys.version_info >= (3, 7):
+            try:
+                kwargs["mp_context"] = multiprocessing.get_context("fork")
+            except ValueError:
+                pass
+        return concurrent.futures.ProcessPoolExecutor(max_workers=self.num_workers, **kwargs)
+
     def __init__(
         self,
         loop,
@@ -185,7 +196,7 @@ class JobManager:
             logger.debug("Adjusting number of worker to 1")
             self.num_workers = 1
         self.num_threads = num_threads or self.num_workers
-        self.process_queue = process_queue or concurrent.futures.ProcessPoolExecutor(max_workers=self.num_workers)
+        self.process_queue = process_queue or self._get_process_executor()
         # notes on fixing BPE (BrokenProcessPool Exception):
         # whenever a process exits unexpectedly, BPE is raised, and while that
         # all the processes in the pool gets a SIGTERM from the management
@@ -255,7 +266,7 @@ class JobManager:
                 if recycling:
                     # now replace
                     logger.info("Replacing process queue with new one")
-                    self.process_queue = concurrent.futures.ProcessPoolExecutor(max_workers=self.num_workers)
+                    self.process_queue = self._get_process_executor()
                 else:
                     self.process_queue = None
             except Exception as e:
@@ -469,7 +480,7 @@ class JobManager:
                 # we don't need to care about the remaining tasks because
                 # they'd all be SIGTERM'd anyways. But ...
                 logger.warning("Broken Process Pool: %s, restarting.", e)
-                self.process_queue = concurrent.futures.ProcessPoolExecutor(max_workers=self.num_workers)
+                self.process_queue = self._get_process_executor()
                 for stale_id in self._process_job_ids:
                     self.jobs.pop(stale_id, None)  # in the rare case that
                     # somehow they de-sync

--- a/biothings/utils/manager.py
+++ b/biothings/utils/manager.py
@@ -171,6 +171,14 @@ class JobManager:
     def _get_process_executor(self):
         kwargs = {}
         if sys.version_info >= (3, 7):
+            # since Python 3.14, multiprocessing uses `forkserver` as the default, instead of 'fork'
+            # on POSIX systems. This breaks our current biothings JobManager when creating dynamic
+            # classes in worker processes (e.g. AssistedDumper_<src_name> class), as the 'forkserver'
+            # context does not inherit resources from the parent process.
+            # This is a quick fix to force using 'fork' context for ProcessPoolExecutor in 3.14,
+            # consistent with previous Python versions.
+            # REF: https://docs.python.org/3.14/library/multiprocessing.html#contexts-and-start-methods
+            # TODO: we should consider refactoring the code to be compatible with 'forkserver' context in the future.
             try:
                 kwargs["mp_context"] = multiprocessing.get_context("fork")
             except ValueError:


### PR DESCRIPTION
When we test the latest Python 3.14 (both regular and free-threaded builds) with the biothings hub at `1.1.x` branch, we had this error for any manifest-based data plugin during either dumping or uploading steps:

<details>
<summary>Full traceback in Python 3.14</summary>

```
Process ForkServerProcess-2:
Traceback (most recent call last):
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/multiprocessing/process.py", line 320, in _bootstrap
    self.run()
    ~~~~~~~~^^
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/concurrent/futures/process.py", line 242, in _process_worker
    call_item = call_queue.get(block=True)
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/multiprocessing/queues.py", line 120, in get
    return _ForkingPickler.loads(res)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^
AttributeError: module 'biothings.hub.dataplugin.templates' has no attribute 'AssistedDumper_hpo'. Did you mean: 'AssistedDumper'?
Process ForkServerProcess-1:
Traceback (most recent call last):
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/multiprocessing/process.py", line 320, in _bootstrap
    self.run()
    ~~~~~~~~^^
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/concurrent/futures/process.py", line 242, in _process_worker
    call_item = call_queue.get(block=True)
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/multiprocessing/queues.py", line 120, in get
    return _ForkingPickler.loads(res)
           ~~~~~~~~~~~~~~~~~~~~~^^^^^
AttributeError: module 'biothings.hub.dataplugin.templates' has no attribute 'AssistedDumper_hpo'. Did you mean: 'AssistedDumper'?
INFO:tornado.access:200 GET /job_manager (172.24.240.102) 9.06ms
ERROR:asyncio:Exception in callback JobManager.defer_to_process.<locals>.run.<locals>.ran() at /home/biothings/biothings_studio/biothings/utils/manager.py:486
handle: <Handle JobManager.defer_to_process.<locals>.run.<locals>.ran() at /home/biothings/biothings_studio/biothings/utils/manager.py:486>
Traceback (most recent call last):
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/biothings/biothings_studio/biothings/utils/manager.py", line 490, in ran
    f.result()
    ~~~~~~~~^^
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.
ERROR:asyncio:Exception in callback JobManager.defer_to_process.<locals>.run.<locals>.ran() at /home/biothings/biothings_studio/biothings/utils/manager.py:486
handle: <Handle JobManager.defer_to_process.<locals>.run.<locals>.ran() at /home/biothings/biothings_studio/biothings/utils/manager.py:486>
Traceback (most recent call last):
  File "/home/biothings/.local/share/uv/python/cpython-3.14.2-linux-x86_64-gnu/lib/python3.14/asyncio/events.py", line 94, in _run
    self._context.run(self._callback, *self._args)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/biothings/biothings_studio/biothings/utils/manager.py", line 490, in ran
    f.result()
    ~~~~~~~~^^
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.
ERROR:dump_hpo:Error downloading 'http://purl.obolibrary.org/obo/hp/hpoa/phenotype_to_genes.txt': A process in the process pool was terminated abruptly while the future was running or pending.
Traceback (most recent call last):
  File "/home/biothings/biothings_studio/biothings/hub/dataload/dumper.py", line 616, in done
    _ = f.result()
  File "/home/biothings/biothings_studio/biothings/utils/manager.py", line 501, in run
    res = await res
          ^^^^^^^^^
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.
ERROR:dump_hpo:Error downloading 'http://purl.obolibrary.org/obo/hp/hpoa/phenotype_to_genes.txt': A process in the process pool was terminated abruptly while the future was running or pending.
Traceback (most recent call last):
  File "/home/biothings/biothings_studio/biothings/hub/dataload/dumper.py", line 616, in done
    _ = f.result()
  File "/home/biothings/biothings_studio/biothings/utils/manager.py", line 501, in run
    res = await res
          ^^^^^^^^^
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.
ERROR:dump_hpo:Error while dumping source: A process in the process pool was terminated abruptly while the future was running or pending.
ERROR:dump_hpo:Traceback (most recent call last):
  File "/home/biothings/biothings_studio/biothings/hub/dataload/dumper.py", line 467, in dump
    await self.do_dump(job_manager=job_manager)
  File "/home/biothings/biothings_studio/biothings/hub/dataload/dumper.py", line 643, in do_dump
    await asyncio.gather(*jobs)
  File "/home/biothings/biothings_studio/biothings/hub/dataload/dumper.py", line 616, in done
    _ = f.result()
  File "/home/biothings/biothings_studio/biothings/utils/manager.py", line 501, in run
    res = await res
          ^^^^^^^^^
concurrent.futures.process.BrokenProcessPool: A process in the process pool was terminated abruptly while the future was running or pending.

ERROR:dump_hpo:failed [steps=dump,post]: A process in the process pool was terminated abruptly while the future was running or pending.
```

</details>

The fix for now is to force the `fork` behavior of the `multiprocessing` module in Python 3.14, but eventually we should consider refactor the code to work with the "safer" `forkserver` mode.

REF: https://docs.python.org/3.14/library/multiprocessing.html#contexts-and-start-methods