### PR TITLE
Remove excess bracket

### DIFF
--- a/biothings/hub/api/handlers/base.py
+++ b/biothings/hub/api/handlers/base.py
@@ -27,7 +27,7 @@ class DefaultHandler(RequestHandler):
             #     "status": "ok"
             # }, iso_dates=True)
             serializer.to_json({
-                {"result": result, "status": "ok"},
+                "result": result, "status": "ok"
             })
         )
 


### PR DESCRIPTION
This PR fixes a `TypeError` caused by a pair of excess brackets used when calling`serializer.to_json` in the api base handlers.