### PR TITLE
Build cleanup

### DIFF
--- a/biothings/hub/__init__.py
+++ b/biothings/hub/__init__.py
@@ -1520,9 +1520,9 @@ class HubServer:
         if "validate_snapshots" in cmdnames:
             self.api_endpoints["validate_snapshots"] = EndpointDefinition(name="validate_snapshots", method="post")
         if "list_mongo_builds" in cmdnames:
-            self.api_endpoints["list_mongo_builds"] = EndpointDefinition(name="list_mongo_builds", method="get")
+            self.api_endpoints["mongo_builds"] = EndpointDefinition(name="list_mongo_builds", method="get")
         if "delete_mongo_builds" in cmdnames:
-            self.api_endpoints["delete_mongo_builds"] = EndpointDefinition(
+            self.api_endpoints["mongo_builds/delete"] = EndpointDefinition(
                 name="delete_mongo_builds", method="put", force_bodyargs=True
             )
         if "sync" in cmdnames:

--- a/biothings/hub/__init__.py
+++ b/biothings/hub/__init__.py
@@ -701,6 +701,7 @@ class HubServer:
 
     def configure_snapshot_manager(self):
         assert "index" in self.features, "'snapshot' feature requires 'index'"
+        from biothings.hub.dataindex.mongo_build_cleanup import MongoBuildCleanupManager
         from biothings.hub.dataindex.snapshooter import SnapshotManager
 
         args = self.mixargs("snapshot")
@@ -713,6 +714,7 @@ class HubServer:
         snapshot_manager.configure(config.SNAPSHOT_CONFIG)
         snapshot_manager.poll("snapshot", snapshot_manager.snapshot_a_build)
         self.managers["snapshot_manager"] = snapshot_manager
+        self.managers["mongo_build_cleanup_manager"] = MongoBuildCleanupManager(job_manager=self.managers["job_manager"])
 
     def configure_auto_snapshot_cleaner_manager(self):
         assert "snapshot" in self.features, "'auto_snapshot_cleaner' feature requires 'snapshot'"
@@ -1148,6 +1150,9 @@ class HubServer:
             self.commands["list_snapshots"] = self.managers["snapshot_manager"].list_snapshots
             self.commands["delete_snapshots"] = self.managers["snapshot_manager"].delete_snapshots
             self.commands["validate_snapshots"] = self.managers["snapshot_manager"].validate_snapshots
+        if self.managers.get("mongo_build_cleanup_manager"):
+            self.commands["list_mongo_builds"] = self.managers["mongo_build_cleanup_manager"].list_mongo_builds
+            self.commands["delete_mongo_builds"] = self.managers["mongo_build_cleanup_manager"].delete_mongo_builds
         # data release commands
         if self.managers.get("release_manager"):
             self.commands["create_release_note"] = self.managers["release_manager"].create_release_note
@@ -1514,6 +1519,12 @@ class HubServer:
             )
         if "validate_snapshots" in cmdnames:
             self.api_endpoints["validate_snapshots"] = EndpointDefinition(name="validate_snapshots", method="post")
+        if "list_mongo_builds" in cmdnames:
+            self.api_endpoints["list_mongo_builds"] = EndpointDefinition(name="list_mongo_builds", method="get")
+        if "delete_mongo_builds" in cmdnames:
+            self.api_endpoints["delete_mongo_builds"] = EndpointDefinition(
+                name="delete_mongo_builds", method="put", force_bodyargs=True
+            )
         if "sync" in cmdnames:
             self.api_endpoints["sync"] = EndpointDefinition(name="sync", method="post", force_bodyargs=True)
         if "whatsnew" in cmdnames:

--- a/biothings/hub/__init__.py
+++ b/biothings/hub/__init__.py
@@ -1153,6 +1153,7 @@ class HubServer:
         if self.managers.get("mongo_build_cleanup_manager"):
             self.commands["list_mongo_builds"] = self.managers["mongo_build_cleanup_manager"].list_mongo_builds
             self.commands["delete_mongo_builds"] = self.managers["mongo_build_cleanup_manager"].delete_mongo_builds
+            self.commands["validate_mongo_builds"] = self.managers["mongo_build_cleanup_manager"].validate_mongo_builds
         # data release commands
         if self.managers.get("release_manager"):
             self.commands["create_release_note"] = self.managers["release_manager"].create_release_note
@@ -1524,6 +1525,10 @@ class HubServer:
         if "delete_mongo_builds" in cmdnames:
             self.api_endpoints["mongo_builds/delete"] = EndpointDefinition(
                 name="delete_mongo_builds", method="put", force_bodyargs=True
+            )
+        if "validate_mongo_builds" in cmdnames:
+            self.api_endpoints["mongo_builds/validate"] = EndpointDefinition(
+                name="validate_mongo_builds", method="post"
             )
         if "sync" in cmdnames:
             self.api_endpoints["sync"] = EndpointDefinition(name="sync", method="post", force_bodyargs=True)

--- a/biothings/hub/dataindex/mongo_build_cleanup.py
+++ b/biothings/hub/dataindex/mongo_build_cleanup.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from biothings import config as btconfig
 from biothings.hub.manager import BaseManager
 from biothings.utils.hub_db import get_src_build
 from config import logger as logging
@@ -36,22 +37,59 @@ class MongoBuildCleaner:
 
     async def delete_builds(self, build_ids):
         if not build_ids:
-            return {"deleted_count": 0}
+            return {
+                "deleted_count": 0,
+                "target_collections_deleted_count": 0,
+                "target_collections_deleted": [],
+            }
 
         from biothings.utils import mongo
 
         conn = mongo.get_hub_db_async_conn()
         try:
             src_build = mongo.get_src_build_async(conn)
+
+            build_docs = []
+            async for doc in src_build.find({"_id": {"$in": build_ids}}, {"_id": 1, "target_name": 1}):
+                build_docs.append(doc)
+
+            target_collection_candidates = set()
+            for doc in build_docs:
+                build_id = doc["_id"]
+                target_name = doc.get("target_name")
+                target_collection_candidates.add(build_id)
+                if target_name and target_name != build_id:
+                    target_collection_candidates.add(target_name)
+
+            target_collections_deleted = []
+            if target_collection_candidates:
+                target_db = conn[btconfig.DATA_TARGET_DATABASE]
+                existing_collections = await target_db.list_collection_names(
+                    filter={"name": {"$in": list(target_collection_candidates)}}
+                )
+
+                for collection_name in existing_collections:
+                    await target_db[collection_name].drop()
+                    target_collections_deleted.append(collection_name)
+
             result = await src_build.delete_many({"_id": {"$in": build_ids}})
-            return {"deleted_count": result.deleted_count}
+            return {
+                "deleted_count": result.deleted_count,
+                "target_collections_deleted_count": len(target_collections_deleted),
+                "target_collections_deleted": sorted(target_collections_deleted),
+            }
         finally:
             await conn.close()
 
     def done(self, future):
         try:
             result = future.result()
-            logging.info("Deleted %d MongoDB builds", result.get("deleted_count", 0), extra={"notify": True})
+            logging.info(
+                "Deleted %d MongoDB builds and dropped %d target collections",
+                result.get("deleted_count", 0),
+                result.get("target_collections_deleted_count", 0),
+                extra={"notify": True},
+            )
         except Exception as exc:
             logging.exception("Failed to delete MongoDB builds: %s", exc, extra={"notify": True})
 

--- a/biothings/hub/dataindex/mongo_build_cleanup.py
+++ b/biothings/hub/dataindex/mongo_build_cleanup.py
@@ -1,0 +1,74 @@
+from functools import partial
+
+from biothings.hub.manager import BaseManager
+from biothings.utils.hub_db import get_src_build
+from config import logger as logging
+
+
+class MongoBuildCleaner:
+    def __init__(self, job_manager):
+        self.job_manager = job_manager
+
+    def list_builds(self, build_config=None, build_name=None):
+        collection = get_src_build()
+
+        filters = {}
+        if build_config:
+            filters["build_config._id"] = build_config
+        if build_name:
+            filters["_id"] = build_name
+
+        projection = {
+            "_id": 1,
+            "build_config": 1,
+            "started_at": 1,
+            "archived": 1,
+            "target_name": 1,
+        }
+        builds = list(collection.find(filters, projection).sort("started_at", -1))
+
+        grouped = {}
+        for build in builds:
+            group_name = build.get("build_config", {}).get("_id") or "N/A"
+            grouped.setdefault(group_name, []).append(build)
+
+        return [{"_id": key, "items": items} for key, items in grouped.items()]
+
+    async def delete_builds(self, build_ids):
+        if not build_ids:
+            return {"deleted_count": 0}
+
+        from biothings.utils import mongo
+
+        conn = mongo.get_hub_db_async_conn()
+        try:
+            src_build = mongo.get_src_build_async(conn)
+            result = await src_build.delete_many({"_id": {"$in": build_ids}})
+            return {"deleted_count": result.deleted_count}
+        finally:
+            conn.close()
+
+    def done(self, future):
+        try:
+            result = future.result()
+            logging.info("Deleted %d MongoDB builds", result.get("deleted_count", 0), extra={"notify": True})
+        except Exception as exc:
+            logging.exception("Failed to delete MongoDB builds: %s", exc, extra={"notify": True})
+
+
+class MongoBuildCleanupManager(BaseManager):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cleaner = MongoBuildCleaner(self.job_manager)
+
+    def list_mongo_builds(self, build_config=None, build_name=None):
+        return self.cleaner.list_builds(build_config=build_config, build_name=build_name)
+
+    def delete_mongo_builds(self, build_ids):
+        try:
+            job = self.job_manager.submit(partial(self.cleaner.delete_builds, build_ids))
+            job.add_done_callback(self.cleaner.done)
+        except Exception as ex:
+            logging.exception("Error while submitting MongoDB build deletion job: %s", ex, extra={"notify": True})
+            raise
+        return job

--- a/biothings/hub/dataindex/mongo_build_cleanup.py
+++ b/biothings/hub/dataindex/mongo_build_cleanup.py
@@ -10,7 +10,7 @@ class MongoBuildCleaner:
     def __init__(self, job_manager):
         self.job_manager = job_manager
 
-    def list_builds(self, build_config=None, build_name=None):
+    def list_builds(self, build_config=None, build_name=None, year=None):
         collection = get_src_build()
 
         filters = {}
@@ -18,6 +18,14 @@ class MongoBuildCleaner:
             filters["build_config._id"] = build_config
         if build_name:
             filters["_id"] = build_name
+        if year:
+            from datetime import datetime
+
+            year = int(year)
+            filters["started_at"] = {
+                "$gte": datetime(year, 1, 1),
+                "$lt": datetime(year + 1, 1, 1),
+            }
 
         projection = {
             "_id": 1,
@@ -81,6 +89,51 @@ class MongoBuildCleaner:
         finally:
             await conn.close()
 
+    async def validate_builds(self):
+        """Validate that target collections exist for each build record.
+
+        Checks every build in src_build to see if its target collection still
+        exists in the target database.  Build records whose target collections
+        have been removed are deleted, keeping the database in sync with the
+        actual data.
+
+        Returns a dict with ``builds_removed`` (count) and ``builds_removed_names``.
+        """
+        from biothings.utils import mongo
+
+        logging.info("Starting validation of MongoDB builds...")
+        conn = mongo.get_hub_db_async_conn()
+        try:
+            src_build = mongo.get_src_build_async(conn)
+            target_db = conn[btconfig.DATA_TARGET_DATABASE]
+
+            existing_collections = set(await target_db.list_collection_names())
+
+            orphaned_ids = []
+            async for doc in src_build.find({}, {"_id": 1, "target_name": 1}):
+                build_id = doc["_id"]
+                target_name = doc.get("target_name") or build_id
+                if target_name not in existing_collections:
+                    orphaned_ids.append(build_id)
+
+            if orphaned_ids:
+                result = await src_build.delete_many({"_id": {"$in": orphaned_ids}})
+                deleted_count = result.deleted_count
+            else:
+                deleted_count = 0
+
+            logging.info(
+                "Build validation complete: removed %d orphaned build record(s)",
+                deleted_count,
+                extra={"notify": True},
+            )
+            return {
+                "builds_removed": deleted_count,
+                "builds_removed_names": sorted(orphaned_ids),
+            }
+        finally:
+            await conn.close()
+
     def done(self, future):
         try:
             result = future.result()
@@ -93,14 +146,25 @@ class MongoBuildCleaner:
         except Exception as exc:
             logging.exception("Failed to delete MongoDB builds: %s", exc, extra={"notify": True})
 
+    def validate_done(self, future):
+        try:
+            result = future.result()
+            logging.info(
+                "Build validation complete: removed %d orphaned build record(s)",
+                result.get("builds_removed", 0),
+                extra={"notify": True},
+            )
+        except Exception as exc:
+            logging.exception("Failed to validate MongoDB builds: %s", exc, extra={"notify": True})
+
 
 class MongoBuildCleanupManager(BaseManager):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.cleaner = MongoBuildCleaner(self.job_manager)
 
-    def list_mongo_builds(self, build_config=None, build_name=None):
-        return self.cleaner.list_builds(build_config=build_config, build_name=build_name)
+    def list_mongo_builds(self, build_config=None, build_name=None, year=None):
+        return self.cleaner.list_builds(build_config=build_config, build_name=build_name, year=year)
 
     def delete_mongo_builds(self, build_ids):
         try:
@@ -108,5 +172,14 @@ class MongoBuildCleanupManager(BaseManager):
             job.add_done_callback(self.cleaner.done)
         except Exception as ex:
             logging.exception("Error while submitting MongoDB build deletion job: %s", ex, extra={"notify": True})
+            raise
+        return job
+
+    def validate_mongo_builds(self):
+        try:
+            job = self.job_manager.submit(partial(self.cleaner.validate_builds))
+            job.add_done_callback(self.cleaner.validate_done)
+        except Exception as ex:
+            logging.exception("Error while submitting MongoDB build validation job: %s", ex, extra={"notify": True})
             raise
         return job

--- a/biothings/hub/dataindex/mongo_build_cleanup.py
+++ b/biothings/hub/dataindex/mongo_build_cleanup.py
@@ -46,7 +46,7 @@ class MongoBuildCleaner:
             result = await src_build.delete_many({"_id": {"$in": build_ids}})
             return {"deleted_count": result.deleted_count}
         finally:
-            conn.close()
+            await conn.close()
 
     def done(self, future):
         try:

--- a/biothings/hub/dataindex/snapshooter.py
+++ b/biothings/hub/dataindex/snapshooter.py
@@ -8,9 +8,8 @@ from datetime import datetime
 from functools import partial
 
 import boto3
-from config import logger as logging
 from elasticsearch import Elasticsearch
-from elasticsearch.exceptions import TransportError, NotFoundError
+from elasticsearch.exceptions import NotFoundError, TransportError
 
 from biothings import config as btconfig
 from biothings.hub import SNAPSHOOTER_CATEGORY
@@ -22,6 +21,7 @@ from biothings.utils.exceptions import RepositoryVerificationFailed
 from biothings.utils.hub import template_out
 from biothings.utils.hub_db import get_src_build
 from biothings.utils.loggers import get_logger
+from config import logger as logging
 
 from . import snapshot_cleanup as cleaner, snapshot_registrar as registrar
 from .snapshot_repo import Repository

--- a/biothings/utils/mongo.py
+++ b/biothings/utils/mongo.py
@@ -10,7 +10,7 @@ from functools import partial, wraps
 
 import bson
 import dateutil.parser as date_parser
-from pymongo import DESCENDING, MongoClient
+from pymongo import DESCENDING, AsyncMongoClient, MongoClient
 from pymongo.client_session import ClientSession
 from pymongo.collection import Collection as PymongoCollection
 from pymongo.database import Database as PymongoDatabase
@@ -155,6 +155,10 @@ class DatabaseClient(HandleAutoReconnectMixin, MongoClient, IDatabase):
         return Database(self, name)
 
 
+class AsyncDatabaseClient(AsyncMongoClient):
+    pass
+
+
 def requires_config(func):
     @wraps(func)
     def func_wrapper(*args, **kwargs):
@@ -193,6 +197,12 @@ def get_hub_db_conn():
 
 
 @requires_config
+def get_hub_db_async_conn():
+    conn = AsyncDatabaseClient(config.HUB_DB_BACKEND["uri"])
+    return conn
+
+
+@requires_config
 def get_src_conn():
     return get_conn(config.DATA_SRC_SERVER, getattr(config, "DATA_SRC_PORT", 27017))
 
@@ -218,6 +228,12 @@ def get_src_dump(conn=None):
 @requires_config
 def get_src_build(conn=None):
     conn = conn or get_hub_db_conn()
+    return conn[config.DATA_HUB_DB_DATABASE][config.DATA_SRC_BUILD_COLLECTION]
+
+
+@requires_config
+def get_src_build_async(conn=None):
+    conn = conn or get_hub_db_async_conn()
     return conn[config.DATA_HUB_DB_DATABASE][config.DATA_SRC_BUILD_COLLECTION]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,11 +86,11 @@ opensearch = [
 ]
 # minimal requirements for running biothings.hub, e.g. in CLI mode
 hubcore = [
-    "pymongo>=4.1.0,<5.0",  # support MongoDB 5.0 since v3.12.0
+    "pymongo>=4.13.0,<5.0",  # AsyncMongoClient stable since 4.13.0
 ]
 # extra requirements to run a full biothings.hub
 hub = [
-    "pymongo>=4.1.0,<5.0",
+    "pymongo>=4.13.0,<5.0",
     "beautifulsoup4",  # used in dumper.GoogleDriveDumper
     "aiocron==1.8",  # setup scheduled jobs
     # "aiohttp==3.8.4",  # elasticsearch requires aiohttp>=3,<4
@@ -120,7 +120,7 @@ hub = [
 ]
 # minimal requirements for to run biothings CLI
 cli = [
-    "pymongo>=4.1.0,<5.0",  # support MongoDB 5.0 since v3.12.0
+    "pymongo>=4.13.0,<5.0",  # AsyncMongoClient stable since 4.13.0
     "psutil",
     "jsonschema>=2.6.0",
     "typer>=0.17.0",  # required for CLI, also installs rich package


### PR DESCRIPTION
This pull request introduces a new manager for cleaning up MongoDB build records and their associated collections, adds asynchronous MongoDB support, and exposes new commands and API endpoints for build management. The changes enhance the hub's ability to list, delete, and validate build records, keeping the database in sync with actual data and improving maintainability.

MongoDB Build Cleanup Features:

* Added `MongoBuildCleanupManager` and `MongoBuildCleaner` classes in `biothings/hub/dataindex/mongo_build_cleanup.py` to support listing, deleting, and validating MongoDB build records and their target collections asynchronously.
* Integrated the new manager into the hub initialization (`biothings/hub/__init__.py`), registering it and exposing its methods as commands (`list_mongo_builds`, `delete_mongo_builds`, `validate_mongo_builds`). [[1]](diffhunk://#diff-1bf8a09d697d27b9798450c3f1d156908150d83a5ab798b528226d4f3ba69184R704) [[2]](diffhunk://#diff-1bf8a09d697d27b9798450c3f1d156908150d83a5ab798b528226d4f3ba69184R717) [[3]](diffhunk://#diff-1bf8a09d697d27b9798450c3f1d156908150d83a5ab798b528226d4f3ba69184R1153-R1156)

API and Command Exposure:

* Added new API endpoints for MongoDB build management (`mongo_builds`, `mongo_builds/delete`, `mongo_builds/validate`) in `biothings/hub/__init__.py`.

Async MongoDB Support:

* Introduced `AsyncMongoClient` and related async helper functions in `biothings/utils/mongo.py` to enable asynchronous database operations, used by the new cleanup manager. [[1]](diffhunk://#diff-70865aa925d2121f214e2b07b681dd85c805f3aa75b435540e349d223f3df2feL13-R13) [[2]](diffhunk://#diff-70865aa925d2121f214e2b07b681dd85c805f3aa75b435540e349d223f3df2feR158-R161) [[3]](diffhunk://#diff-70865aa925d2121f214e2b07b681dd85c805f3aa75b435540e349d223f3df2feR199-R204) [[4]](diffhunk://#diff-70865aa925d2121f214e2b07b681dd85c805f3aa75b435540e349d223f3df2feR234-R239)

Dependency Update:

* Updated `pyproject.toml` to require `pymongo>=4.13.0` for stable `AsyncMongoClient` support. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L89-R93) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L123-R123)

Logging Consistency:

* Minor adjustments to logging imports in `biothings/hub/dataindex/snapshooter.py` for consistency. [[1]](diffhunk://#diff-2b305cf265e1aafccdef3dc108b64858b89c9a0b9755a8de9d9d9a65c5cbdb61L11-R12) [[2]](diffhunk://#diff-2b305cf265e1aafccdef3dc108b64858b89c9a0b9755a8de9d9d9a65c5cbdb61R24)