### PR TITLE
fix: handle NaN-like values in dict_sweep

### DIFF
--- a/biothings/utils/dataload.py
+++ b/biothings/utils/dataload.py
@@ -21,38 +21,50 @@ from .dotstring import key_value, set_key_value
 
 csv.field_size_limit(10000000)  # default is 131072, too small for some big files
 
+
+def _missing_value_kind(val):
+    """Return a stable kind for NaN-like values without importing optional deps."""
+    val_cls = val.__class__
+    cls_module = getattr(val_cls, "__module__", "")
+    cls_name = getattr(val_cls, "__name__", "")
+
+    if (cls_module == "pandas" or cls_module.startswith("pandas.")) and cls_name in ("NAType", "NaTType"):
+        return cls_name
+
+    try:
+        if math.isnan(val):
+            return "NaN"
+    except (TypeError, ValueError):
+        pass
+
+    return None
+
+
 def _val_to_delete(val, vals):
     """Return True if val is considered as a value to delete, False otherwise.
 
     NaN-like values (float NaN, pandas.NA, pandas.NaT) are only removed when
     explicitly included in the vals list.
     """
-    try:
-        # float('nan') != float('nan') by IEEE 754, so `val in vals` always
-        # returns False for NaN floats.  Handle it with math.isnan instead.
-        if isinstance(val, float) and math.isnan(val):
-            return any(isinstance(v, float) and math.isnan(v) for v in vals)
-        to_delete = val in vals
-    except (TypeError, ValueError):
-        # pandas.NA raises TypeError on comparison; pandas.NaT may raise
-        # ValueError.  Catch both so either type is handled.
-        try:
-            val_is_nan = val.__module__ == "pandas" and val.__class__.__name__ in ("NAType", "NaTType")
-        except AttributeError:
-            return False
-        # Only remove if the caller explicitly put a pandas NA/NaT in vals.
-        nan_in_vals = False
-        for v in vals:
-            try:
-                if v.__module__ == "pandas" and v.__class__.__name__ in ("NAType", "NaTType"):
-                    nan_in_vals = True
-                    break
-            except AttributeError:
-                # Regular values (str, int, …) don't have __module__.
-                continue
-        to_delete = val_is_nan and nan_in_vals
+    if is_str(vals):
+        vals = [vals]
 
-    return to_delete
+    val_missing_kind = _missing_value_kind(val)
+
+    for candidate in vals:
+        candidate_missing_kind = _missing_value_kind(candidate)
+        if val_missing_kind or candidate_missing_kind:
+            if val_missing_kind == candidate_missing_kind:
+                return True
+            continue
+
+        try:
+            if val == candidate:
+                return True
+        except (TypeError, ValueError):
+            continue
+
+    return False
 
 
 def dict_sweep(d, vals=None, remove_invalid_list=False):
@@ -96,17 +108,16 @@ def dict_sweep(d, vals=None, remove_invalid_list=False):
                 else:
                     d[key] = val
             else:
-                new_val = []
-                for item in val:
+                i = 0
+                while i < len(val):
+                    item = val[i]
                     if _val_to_delete(item, vals):
-                        continue
+                        del val[i]
                     elif isinstance(item, dict):
                         dict_sweep(item, vals, remove_invalid_list=remove_invalid_list)
-                    new_val.append(item)
-                if not new_val:
+                    i += 1
+                if not val:
                     del d[key]
-                else:
-                    d[key] = new_val
         elif isinstance(val, dict):
             dict_sweep(val, vals, remove_invalid_list=remove_invalid_list)
             # if len(val) == 0:

--- a/biothings/utils/dataload.py
+++ b/biothings/utils/dataload.py
@@ -9,6 +9,7 @@ import csv
 # from __future__ import unicode_literals
 import itertools
 import json
+import math
 import os
 import os.path
 from collections import Counter, OrderedDict
@@ -21,9 +22,21 @@ from .dotstring import key_value, set_key_value
 csv.field_size_limit(10000000)  # default is 131072, too small for some big files
 
 
+def _is_nan(val):
+    """Detect NaN-like values (float NaN, pandas.NA, pandas.NaT)"""
+    try:
+        if isinstance(val, float) and math.isnan(val):
+            return True
+    except (TypeError, ValueError):
+        pass
+    return val.__class__.__name__ in ("NAType", "NaTType")
+
+
 def dict_sweep(d, vals=None, remove_invalid_list=False):
     """
-    Remove keys whose values are ".", "-", "", "NA", "none", " "; and remove empty dictionaries
+    Remove keys whose values are ".", "-", "", "NA", "none", " "; and remove empty dictionaries.
+
+    NaN-like values (float NaN, pandas.NA, pandas.NaT) are always removed regardless of the vals list.
 
     Args:
         d (dict): a dictionary
@@ -45,11 +58,11 @@ def dict_sweep(d, vals=None, remove_invalid_list=False):
     # set default supported vals for empty values
     vals = vals or [".", "-", "", "NA", "none", " ", "Not Available", "unknown"]
     for key, val in list(d.items()):
-        if val in vals:
+        if _is_nan(val) or val in vals:
             del d[key]
         elif isinstance(val, list):
             if remove_invalid_list:
-                val = [v for v in val if v not in vals]
+                val = [v for v in val if not _is_nan(v) and v not in vals]
                 for item in val:
                     if isinstance(item, dict):
                         dict_sweep(item, vals, remove_invalid_list=remove_invalid_list)
@@ -59,14 +72,17 @@ def dict_sweep(d, vals=None, remove_invalid_list=False):
                 else:
                     d[key] = val
             else:
+                new_val = []
                 for item in val:
-                    if item in vals:
-                        val.remove(item)
+                    if _is_nan(item) or item in vals:
+                        continue
                     elif isinstance(item, dict):
                         dict_sweep(item, vals, remove_invalid_list=remove_invalid_list)
-                # if len(val) == 0:
-                if not val:
+                    new_val.append(item)
+                if not new_val:
                     del d[key]
+                else:
+                    d[key] = new_val
         elif isinstance(val, dict):
             dict_sweep(val, vals, remove_invalid_list=remove_invalid_list)
             # if len(val) == 0:

--- a/biothings/utils/dataload.py
+++ b/biothings/utils/dataload.py
@@ -21,22 +21,46 @@ from .dotstring import key_value, set_key_value
 
 csv.field_size_limit(10000000)  # default is 131072, too small for some big files
 
+def _val_to_delete(val, vals):
+    """Return True if val is considered as a value to delete, False otherwise.
 
-def _is_nan(val):
-    """Detect NaN-like values (float NaN, pandas.NA, pandas.NaT)"""
+    NaN-like values (float NaN, pandas.NA, pandas.NaT) are only removed when
+    explicitly included in the vals list.
+    """
     try:
+        # float('nan') != float('nan') by IEEE 754, so `val in vals` always
+        # returns False for NaN floats.  Handle it with math.isnan instead.
         if isinstance(val, float) and math.isnan(val):
-            return True
+            return any(isinstance(v, float) and math.isnan(v) for v in vals)
+        to_delete = val in vals
     except (TypeError, ValueError):
-        pass
-    return val.__class__.__name__ in ("NAType", "NaTType")
+        # pandas.NA raises TypeError on comparison; pandas.NaT may raise
+        # ValueError.  Catch both so either type is handled.
+        try:
+            val_is_nan = val.__module__ == "pandas" and val.__class__.__name__ in ("NAType", "NaTType")
+        except AttributeError:
+            return False
+        # Only remove if the caller explicitly put a pandas NA/NaT in vals.
+        nan_in_vals = False
+        for v in vals:
+            try:
+                if v.__module__ == "pandas" and v.__class__.__name__ in ("NAType", "NaTType"):
+                    nan_in_vals = True
+                    break
+            except AttributeError:
+                # Regular values (str, int, …) don't have __module__.
+                continue
+        to_delete = val_is_nan and nan_in_vals
+
+    return to_delete
 
 
 def dict_sweep(d, vals=None, remove_invalid_list=False):
     """
     Remove keys whose values are ".", "-", "", "NA", "none", " "; and remove empty dictionaries.
 
-    NaN-like values (float NaN, pandas.NA, pandas.NaT) are always removed regardless of the vals list.
+    NaN-like values (float NaN, pandas.NA, pandas.NaT) are only removed when
+    explicitly included in the ``vals`` list.
 
     Args:
         d (dict): a dictionary
@@ -58,11 +82,11 @@ def dict_sweep(d, vals=None, remove_invalid_list=False):
     # set default supported vals for empty values
     vals = vals or [".", "-", "", "NA", "none", " ", "Not Available", "unknown"]
     for key, val in list(d.items()):
-        if _is_nan(val) or val in vals:
+        if _val_to_delete(val, vals):
             del d[key]
         elif isinstance(val, list):
             if remove_invalid_list:
-                val = [v for v in val if not _is_nan(v) and v not in vals]
+                val = [v for v in val if not _val_to_delete(v, vals)]
                 for item in val:
                     if isinstance(item, dict):
                         dict_sweep(item, vals, remove_invalid_list=remove_invalid_list)
@@ -74,7 +98,7 @@ def dict_sweep(d, vals=None, remove_invalid_list=False):
             else:
                 new_val = []
                 for item in val:
-                    if _is_nan(item) or item in vals:
+                    if _val_to_delete(item, vals):
                         continue
                     elif isinstance(item, dict):
                         dict_sweep(item, vals, remove_invalid_list=remove_invalid_list)

--- a/tests/utils/test_dataload.py
+++ b/tests/utils/test_dataload.py
@@ -1,20 +1,26 @@
 """
-Tests for dict_sweep and _is_nan in biothings.utils.dataload,
+Tests for dict_sweep and _val_to_delete in biothings.utils.dataload,
 specifically the handling of NaN-like values.
+
+NaN-like values (float NaN, pandas.NA, pandas.NaT) are only removed
+when explicitly included in the vals list (opt-in).
 """
 
 import math
 
 import pytest
 
-from biothings.utils.dataload import _is_nan, dict_sweep
+from biothings.utils.dataload import _val_to_delete, dict_sweep
 
 # ---------------------------------------------------------------------------
-# Fake pandas-like NA / NaT types for testing without importing pandas
+# Fake pandas-like NA / NaT types for testing without importing pandas.
+# __module__ is set to "pandas" so that _val_to_delete's module check works.
 # ---------------------------------------------------------------------------
 
 class NAType:
     """Mimics pandas.NA (pandas.core.arrays.masked.NAType)."""
+    __module__ = "pandas"
+
     def __bool__(self):
         raise TypeError("boolean value of NA is ambiguous")
 
@@ -30,6 +36,8 @@ class NAType:
 
 class NaTType:
     """Mimics pandas.NaT (pandas._libs.tslibs.nattype.NaTType)."""
+    __module__ = "pandas"
+
     def __bool__(self):
         raise TypeError("boolean value of NaT is ambiguous")
 
@@ -46,132 +54,184 @@ class NaTType:
 _NA = NAType()
 _NaT = NaTType()
 
-
-# ---------------------------------------------------------------------------
-# _is_nan helper tests
-# ---------------------------------------------------------------------------
-
-class TestIsNan:
-    def test_float_nan(self):
-        assert _is_nan(float("nan")) is True
-
-    def test_na_type(self):
-        assert _is_nan(_NA) is True
-
-    def test_nat_type(self):
-        assert _is_nan(_NaT) is True
-
-    def test_regular_values_are_not_nan(self):
-        for val in [0, 1, -1, "", "hello", None, [], {}, 0.0, 1.5, True, False]:
-            assert _is_nan(val) is False, f"_is_nan should be False for {val!r}"
+_DEFAULT_VALS = [".", "-", "", "NA", "none", " ", "Not Available", "unknown"]
+_VALS_WITH_NAN = _DEFAULT_VALS + [float("nan"), _NA, _NaT]
 
 
 # ---------------------------------------------------------------------------
-# dict_sweep tests — NaN-like values at top level
+# _val_to_delete helper tests
 # ---------------------------------------------------------------------------
 
-class TestDictSweepNanTopLevel:
-    def test_float_nan_removed(self):
+class TestValToDelete:
+    # -- default vals (no NaN entries) -----------------------------------
+
+    def test_default_vals_matched(self):
+        for val in _DEFAULT_VALS:
+            assert _val_to_delete(val, _DEFAULT_VALS) is True, f"should delete {val!r}"
+
+    def test_regular_values_not_deleted(self):
+        for val in [0, 1, -1, "hello", None, [], {}, 0.0, 1.5, True, False]:
+            assert _val_to_delete(val, _DEFAULT_VALS) is False, f"should keep {val!r}"
+
+    def test_float_nan_not_deleted_by_default(self):
+        """float NaN is kept when vals does not contain a NaN float."""
+        assert _val_to_delete(float("nan"), _DEFAULT_VALS) is False
+
+    def test_na_not_deleted_by_default(self):
+        """Mock pandas NA is kept when vals does not contain a pandas NA."""
+        assert _val_to_delete(_NA, _DEFAULT_VALS) is False
+
+    def test_nat_not_deleted_by_default(self):
+        """Mock pandas NaT is kept when vals does not contain a pandas NaT."""
+        assert _val_to_delete(_NaT, _DEFAULT_VALS) is False
+
+    # -- vals with NaN entries (opt-in) ----------------------------------
+
+    def test_float_nan_deleted_when_in_vals(self):
+        assert _val_to_delete(float("nan"), _VALS_WITH_NAN) is True
+
+    def test_na_deleted_when_in_vals(self):
+        assert _val_to_delete(_NA, _VALS_WITH_NAN) is True
+
+    def test_nat_deleted_when_in_vals(self):
+        assert _val_to_delete(_NaT, _VALS_WITH_NAN) is True
+
+
+# ---------------------------------------------------------------------------
+# dict_sweep — default vals (NaN kept)
+# ---------------------------------------------------------------------------
+
+class TestDictSweepDefaultKeepsNan:
+    def test_float_nan_kept(self):
         d = {"a": 1, "b": float("nan")}
         result = dict_sweep(d)
-        assert result == {"a": 1}
+        assert "b" in result
+        assert math.isnan(result["b"])
 
-    def test_pandas_na_removed(self):
+    def test_na_kept(self):
         d = {"a": 1, "b": _NA}
         result = dict_sweep(d)
-        assert result == {"a": 1}
+        assert "b" in result
+        assert result["b"] is _NA
 
-    def test_pandas_nat_removed(self):
+    def test_nat_kept(self):
         d = {"a": 1, "b": _NaT}
         result = dict_sweep(d)
-        assert result == {"a": 1}
+        assert "b" in result
+        assert result["b"] is _NaT
 
-    def test_multiple_nan_types_removed(self):
-        d = {"a": float("nan"), "b": _NA, "c": _NaT, "d": "keep"}
-        result = dict_sweep(d)
-        assert result == {"d": "keep"}
-
-
-# ---------------------------------------------------------------------------
-# dict_sweep tests — NaN-like values inside lists
-# ---------------------------------------------------------------------------
-
-class TestDictSweepNanInList:
-    def test_nan_removed_from_list(self):
+    def test_nan_kept_in_list(self):
         d = {"a": [1, float("nan"), 2]}
         result = dict_sweep(d)
-        assert result == {"a": [1, 2]}
+        assert len(result["a"]) == 3
 
-    def test_na_removed_from_list(self):
-        d = {"a": [1, _NA, 2]}
-        result = dict_sweep(d)
-        assert result == {"a": [1, 2]}
-
-    def test_nat_removed_from_list(self):
-        d = {"a": [1, _NaT, 2]}
-        result = dict_sweep(d)
-        assert result == {"a": [1, 2]}
-
-    def test_list_becomes_empty_after_nan_removal(self):
-        d = {"a": [float("nan")]}
-        result = dict_sweep(d)
-        assert "a" not in result
-
-    def test_nan_in_list_with_remove_invalid_list(self):
-        d = {"a": [float("nan"), _NA, "valid"]}
-        result = dict_sweep(d, remove_invalid_list=True)
-        assert result == {"a": ["valid"]}
-
-    def test_all_nan_list_removed_with_remove_invalid_list(self):
-        d = {"a": [float("nan"), _NA, _NaT]}
-        result = dict_sweep(d, remove_invalid_list=True)
-        assert "a" not in result
-
-
-# ---------------------------------------------------------------------------
-# dict_sweep tests — NaN-like values in nested dicts
-# ---------------------------------------------------------------------------
-
-class TestDictSweepNanNested:
-    def test_nan_in_nested_dict(self):
-        d = {"a": {"b": float("nan"), "c": 1}}
-        result = dict_sweep(d)
-        assert result == {"a": {"c": 1}}
-
-    def test_na_in_nested_dict(self):
-        d = {"a": {"b": _NA, "c": 1}}
-        result = dict_sweep(d)
-        assert result == {"a": {"c": 1}}
-
-    def test_nested_dict_removed_when_empty_after_sweep(self):
-        d = {"a": {"b": float("nan")}}
-        result = dict_sweep(d)
-        assert "a" not in result
-
-    def test_nan_in_list_of_dicts(self):
-        d = {"a": [{"x": float("nan"), "y": 1}, {"x": _NA, "y": 2}]}
-        result = dict_sweep(d)
-        assert result == {"a": [{"y": 1}, {"y": 2}]}
-
-
-# ---------------------------------------------------------------------------
-# dict_sweep tests — default vals still work
-# ---------------------------------------------------------------------------
-
-class TestDictSweepDefaultBehavior:
     def test_default_vals_still_removed(self):
         d = {"a": ".", "b": "-", "c": "", "d": "keep"}
         result = dict_sweep(d)
         assert result == {"d": "keep"}
 
+
+# ---------------------------------------------------------------------------
+# dict_sweep — opt-in NaN removal (NaN in vals)
+# ---------------------------------------------------------------------------
+
+class TestDictSweepOptInNanRemoval:
+    def test_float_nan_removed(self):
+        d = {"a": 1, "b": float("nan")}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": 1}
+
+    def test_na_removed(self):
+        d = {"a": 1, "b": _NA}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": 1}
+
+    def test_nat_removed(self):
+        d = {"a": 1, "b": _NaT}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": 1}
+
+    def test_multiple_nan_types_removed(self):
+        d = {"a": float("nan"), "b": _NA, "c": _NaT, "d": "keep"}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"d": "keep"}
+
+
+# ---------------------------------------------------------------------------
+# dict_sweep — NaN inside lists (opt-in)
+# ---------------------------------------------------------------------------
+
+class TestDictSweepNanInList:
+    def test_nan_removed_from_list(self):
+        d = {"a": [1, float("nan"), 2]}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": [1, 2]}
+
+    def test_na_removed_from_list(self):
+        d = {"a": [1, _NA, 2]}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": [1, 2]}
+
+    def test_nat_removed_from_list(self):
+        d = {"a": [1, _NaT, 2]}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": [1, 2]}
+
+    def test_list_becomes_empty_after_nan_removal(self):
+        d = {"a": [float("nan")]}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert "a" not in result
+
+    def test_nan_in_list_with_remove_invalid_list(self):
+        d = {"a": [float("nan"), _NA, "valid"]}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN, remove_invalid_list=True)
+        assert result == {"a": ["valid"]}
+
+    def test_all_nan_list_removed_with_remove_invalid_list(self):
+        d = {"a": [float("nan"), _NA, _NaT]}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN, remove_invalid_list=True)
+        assert "a" not in result
+
+
+# ---------------------------------------------------------------------------
+# dict_sweep — NaN in nested dicts (opt-in)
+# ---------------------------------------------------------------------------
+
+class TestDictSweepNanNested:
+    def test_nan_in_nested_dict(self):
+        d = {"a": {"b": float("nan"), "c": 1}}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": {"c": 1}}
+
+    def test_na_in_nested_dict(self):
+        d = {"a": {"b": _NA, "c": 1}}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": {"c": 1}}
+
+    def test_nested_dict_removed_when_empty_after_sweep(self):
+        d = {"a": {"b": float("nan")}}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert "a" not in result
+
+    def test_nan_in_list_of_dicts(self):
+        d = {"a": [{"x": float("nan"), "y": 1}, {"x": _NA, "y": 2}]}
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
+        assert result == {"a": [{"y": 1}, {"y": 2}]}
+
+
+# ---------------------------------------------------------------------------
+# dict_sweep — default vals behaviour unchanged
+# ---------------------------------------------------------------------------
+
+class TestDictSweepDefaultBehavior:
     def test_normal_values_kept(self):
         d = {"a": 1, "b": "hello", "c": [1, 2], "d": {"nested": True}}
         result = dict_sweep(d)
         assert result == {"a": 1, "b": "hello", "c": [1, 2], "d": {"nested": True}}
 
-    def test_mixed_nan_and_default_vals(self):
+    def test_mixed_nan_and_default_vals_with_optin(self):
         d = {"a": float("nan"), "b": ".", "c": _NA, "d": "keep", "e": ""}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=_VALS_WITH_NAN)
         assert result == {"d": "keep"}
 
 
@@ -183,67 +243,89 @@ pandas = pytest.importorskip("pandas")
 numpy = pytest.importorskip("numpy")
 
 
-class TestIsNanRealTypes:
-    def test_numpy_nan(self):
-        assert _is_nan(numpy.nan) is True
+class TestValToDeleteRealTypes:
+    def test_numpy_nan_not_deleted_by_default(self):
+        assert _val_to_delete(numpy.nan, _DEFAULT_VALS) is False
 
-    def test_pandas_na(self):
-        assert _is_nan(pandas.NA) is True
+    def test_pandas_na_not_deleted_by_default(self):
+        assert _val_to_delete(pandas.NA, _DEFAULT_VALS) is False
 
-    def test_pandas_nat(self):
-        assert _is_nan(pandas.NaT) is True
+    def test_pandas_nat_not_deleted_by_default(self):
+        assert _val_to_delete(pandas.NaT, _DEFAULT_VALS) is False
 
-    def test_numpy_float_nan(self):
-        assert _is_nan(numpy.float64("nan")) is True
+    def test_numpy_nan_deleted_when_in_vals(self):
+        vals_with_nan = _DEFAULT_VALS + [float("nan")]
+        assert _val_to_delete(numpy.nan, vals_with_nan) is True
+
+    def test_pandas_na_deleted_when_in_vals(self):
+        vals_with_na = _DEFAULT_VALS + [pandas.NA]
+        assert _val_to_delete(pandas.NA, vals_with_na) is True
+
+    def test_pandas_nat_deleted_when_in_vals(self):
+        vals_with_nat = _DEFAULT_VALS + [pandas.NaT]
+        assert _val_to_delete(pandas.NaT, vals_with_nat) is True
+
+    def test_numpy_float64_nan_deleted_when_in_vals(self):
+        vals_with_nan = _DEFAULT_VALS + [float("nan")]
+        assert _val_to_delete(numpy.float64("nan"), vals_with_nan) is True
 
 
-class TestDictSweepRealPandasNA:
+class TestDictSweepRealPandas:
+    """dict_sweep with real pandas/numpy NaN types and opt-in removal."""
+
+    def _vals_with(self, *extras):
+        return _DEFAULT_VALS + list(extras)
+
     def test_pandas_na_top_level(self):
         d = {"a": 1, "b": pandas.NA}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=self._vals_with(pandas.NA))
         assert result == {"a": 1}
 
     def test_pandas_nat_top_level(self):
         d = {"a": 1, "b": pandas.NaT}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=self._vals_with(pandas.NaT))
         assert result == {"a": 1}
 
     def test_numpy_nan_top_level(self):
         d = {"a": 1, "b": numpy.nan}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=self._vals_with(float("nan")))
         assert result == {"a": 1}
 
     def test_pandas_na_in_list(self):
         d = {"a": [1, pandas.NA, 2]}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=self._vals_with(pandas.NA))
         assert result == {"a": [1, 2]}
 
     def test_pandas_nat_in_list(self):
         d = {"a": [1, pandas.NaT, 2]}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=self._vals_with(pandas.NaT))
         assert result == {"a": [1, 2]}
 
     def test_numpy_nan_in_list(self):
         d = {"a": [1, numpy.nan, 2]}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=self._vals_with(float("nan")))
         assert result == {"a": [1, 2]}
 
     def test_pandas_na_in_nested_dict(self):
         d = {"a": {"b": pandas.NA, "c": 1}}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=self._vals_with(pandas.NA))
         assert result == {"a": {"c": 1}}
 
     def test_pandas_na_in_list_with_remove_invalid_list(self):
         d = {"a": [pandas.NA, pandas.NaT, "valid"]}
-        result = dict_sweep(d, remove_invalid_list=True)
+        result = dict_sweep(d, vals=self._vals_with(pandas.NA, pandas.NaT), remove_invalid_list=True)
         assert result == {"a": ["valid"]}
 
     def test_all_real_nan_types_removed(self):
         d = {"a": numpy.nan, "b": pandas.NA, "c": pandas.NaT, "d": "keep"}
-        result = dict_sweep(d)
+        result = dict_sweep(d, vals=self._vals_with(float("nan"), pandas.NA, pandas.NaT))
         assert result == {"d": "keep"}
 
-    def test_mixed_real_and_default_vals(self):
-        d = {"a": pandas.NA, "b": ".", "c": numpy.nan, "d": "keep", "e": pandas.NaT}
+    def test_real_nan_kept_by_default(self):
+        """Without opting in, real NaN types are preserved."""
+        d = {"a": numpy.nan, "b": pandas.NA, "c": pandas.NaT, "d": "keep"}
         result = dict_sweep(d)
-        assert result == {"d": "keep"}
+        assert "a" in result
+        assert "b" in result
+        assert "c" in result
+        assert result["d"] == "keep"

--- a/tests/utils/test_dataload.py
+++ b/tests/utils/test_dataload.py
@@ -14,12 +14,15 @@ from biothings.utils.dataload import _val_to_delete, dict_sweep
 
 # ---------------------------------------------------------------------------
 # Fake pandas-like NA / NaT types for testing without importing pandas.
-# __module__ is set to "pandas" so that _val_to_delete's module check works.
+# __module__ mirrors real pandas internals closely enough to exercise fallback
+# detection without importing pandas.
 # ---------------------------------------------------------------------------
+
 
 class NAType:
     """Mimics pandas.NA (pandas.core.arrays.masked.NAType)."""
-    __module__ = "pandas"
+
+    __module__ = "pandas._libs.missing"
 
     def __bool__(self):
         raise TypeError("boolean value of NA is ambiguous")
@@ -36,7 +39,8 @@ class NAType:
 
 class NaTType:
     """Mimics pandas.NaT (pandas._libs.tslibs.nattype.NaTType)."""
-    __module__ = "pandas"
+
+    __module__ = "pandas._libs.tslibs.nattype"
 
     def __bool__(self):
         raise TypeError("boolean value of NaT is ambiguous")
@@ -58,9 +62,20 @@ _DEFAULT_VALS = [".", "-", "", "NA", "none", " ", "Not Available", "unknown"]
 _VALS_WITH_NAN = _DEFAULT_VALS + [float("nan"), _NA, _NaT]
 
 
+@pytest.fixture(scope="module")
+def pandas():
+    return pytest.importorskip("pandas")
+
+
+@pytest.fixture(scope="module")
+def numpy():
+    return pytest.importorskip("numpy")
+
+
 # ---------------------------------------------------------------------------
 # _val_to_delete helper tests
 # ---------------------------------------------------------------------------
+
 
 class TestValToDelete:
     # -- default vals (no NaN entries) -----------------------------------
@@ -72,6 +87,9 @@ class TestValToDelete:
     def test_regular_values_not_deleted(self):
         for val in [0, 1, -1, "hello", None, [], {}, 0.0, 1.5, True, False]:
             assert _val_to_delete(val, _DEFAULT_VALS) is False, f"should keep {val!r}"
+
+    def test_string_vals_matched(self):
+        assert _val_to_delete("NA", "NA") is True
 
     def test_float_nan_not_deleted_by_default(self):
         """float NaN is kept when vals does not contain a NaN float."""
@@ -96,10 +114,18 @@ class TestValToDelete:
     def test_nat_deleted_when_in_vals(self):
         assert _val_to_delete(_NaT, _VALS_WITH_NAN) is True
 
+    def test_na_and_nat_are_not_interchangeable(self):
+        assert _val_to_delete(_NA, _DEFAULT_VALS + [_NaT]) is False
+        assert _val_to_delete(_NaT, _DEFAULT_VALS + [_NA]) is False
+
+    def test_regular_match_after_na_like_value(self):
+        assert _val_to_delete("", [_NA, ""]) is True
+
 
 # ---------------------------------------------------------------------------
 # dict_sweep — default vals (NaN kept)
 # ---------------------------------------------------------------------------
+
 
 class TestDictSweepDefaultKeepsNan:
     def test_float_nan_kept(self):
@@ -135,6 +161,7 @@ class TestDictSweepDefaultKeepsNan:
 # dict_sweep — opt-in NaN removal (NaN in vals)
 # ---------------------------------------------------------------------------
 
+
 class TestDictSweepOptInNanRemoval:
     def test_float_nan_removed(self):
         d = {"a": 1, "b": float("nan")}
@@ -160,6 +187,7 @@ class TestDictSweepOptInNanRemoval:
 # ---------------------------------------------------------------------------
 # dict_sweep — NaN inside lists (opt-in)
 # ---------------------------------------------------------------------------
+
 
 class TestDictSweepNanInList:
     def test_nan_removed_from_list(self):
@@ -192,10 +220,21 @@ class TestDictSweepNanInList:
         result = dict_sweep(d, vals=_VALS_WITH_NAN, remove_invalid_list=True)
         assert "a" not in result
 
+    def test_all_invalid_list_preserves_false_mode_behavior(self):
+        d = {"gene": [None, None], "site": ["Intron", None], "snp_build": 136}
+        result = dict_sweep(d, vals=[None], remove_invalid_list=False)
+        assert result == {"gene": [None], "site": ["Intron"], "snp_build": 136}
+
+    def test_all_invalid_list_removed_with_remove_invalid_list(self):
+        d = {"gene": [None, None], "site": ["Intron", None], "snp_build": 136}
+        result = dict_sweep(d, vals=[None], remove_invalid_list=True)
+        assert result == {"site": ["Intron"], "snp_build": 136}
+
 
 # ---------------------------------------------------------------------------
 # dict_sweep — NaN in nested dicts (opt-in)
 # ---------------------------------------------------------------------------
+
 
 class TestDictSweepNanNested:
     def test_nan_in_nested_dict(self):
@@ -223,6 +262,7 @@ class TestDictSweepNanNested:
 # dict_sweep — default vals behaviour unchanged
 # ---------------------------------------------------------------------------
 
+
 class TestDictSweepDefaultBehavior:
     def test_normal_values_kept(self):
         d = {"a": 1, "b": "hello", "c": [1, 2], "d": {"nested": True}}
@@ -234,38 +274,51 @@ class TestDictSweepDefaultBehavior:
         result = dict_sweep(d, vals=_VALS_WITH_NAN)
         assert result == {"d": "keep"}
 
+    def test_string_vals_supported(self):
+        d = {"a": "NA", "b": "keep", "c": ["NA", "keep"]}
+        result = dict_sweep(d, vals="NA")
+        assert result == {"b": "keep", "c": ["keep"]}
+
 
 # ---------------------------------------------------------------------------
-# Tests using real pandas and numpy types
+# Tests using real pandas and numpy types, when the optional deps are installed.
 # ---------------------------------------------------------------------------
-
-pandas = pytest.importorskip("pandas")
-numpy = pytest.importorskip("numpy")
 
 
 class TestValToDeleteRealTypes:
-    def test_numpy_nan_not_deleted_by_default(self):
+    def test_numpy_nan_not_deleted_by_default(self, numpy):
         assert _val_to_delete(numpy.nan, _DEFAULT_VALS) is False
 
-    def test_pandas_na_not_deleted_by_default(self):
+    def test_pandas_na_not_deleted_by_default(self, pandas):
         assert _val_to_delete(pandas.NA, _DEFAULT_VALS) is False
 
-    def test_pandas_nat_not_deleted_by_default(self):
+    def test_pandas_nat_not_deleted_by_default(self, pandas):
         assert _val_to_delete(pandas.NaT, _DEFAULT_VALS) is False
 
-    def test_numpy_nan_deleted_when_in_vals(self):
+    def test_numpy_nan_deleted_when_in_vals(self, numpy):
         vals_with_nan = _DEFAULT_VALS + [float("nan")]
         assert _val_to_delete(numpy.nan, vals_with_nan) is True
 
-    def test_pandas_na_deleted_when_in_vals(self):
+    def test_pandas_na_deleted_when_in_vals(self, pandas):
         vals_with_na = _DEFAULT_VALS + [pandas.NA]
         assert _val_to_delete(pandas.NA, vals_with_na) is True
 
-    def test_pandas_nat_deleted_when_in_vals(self):
+    def test_pandas_nat_deleted_when_in_vals(self, pandas):
         vals_with_nat = _DEFAULT_VALS + [pandas.NaT]
         assert _val_to_delete(pandas.NaT, vals_with_nat) is True
 
-    def test_numpy_float64_nan_deleted_when_in_vals(self):
+    def test_pandas_na_and_nat_are_not_interchangeable(self, pandas):
+        assert _val_to_delete(pandas.NA, _DEFAULT_VALS + [pandas.NaT]) is False
+        assert _val_to_delete(pandas.NaT, _DEFAULT_VALS + [pandas.NA]) is False
+
+    def test_regular_match_after_pandas_na(self, pandas):
+        assert _val_to_delete("", [pandas.NA, ""]) is True
+
+    def test_numpy_float32_nan_deleted_when_in_vals(self, numpy):
+        vals_with_nan = _DEFAULT_VALS + [float("nan")]
+        assert _val_to_delete(numpy.float32("nan"), vals_with_nan) is True
+
+    def test_numpy_float64_nan_deleted_when_in_vals(self, numpy):
         vals_with_nan = _DEFAULT_VALS + [float("nan")]
         assert _val_to_delete(numpy.float64("nan"), vals_with_nan) is True
 
@@ -276,52 +329,52 @@ class TestDictSweepRealPandas:
     def _vals_with(self, *extras):
         return _DEFAULT_VALS + list(extras)
 
-    def test_pandas_na_top_level(self):
+    def test_pandas_na_top_level(self, pandas):
         d = {"a": 1, "b": pandas.NA}
         result = dict_sweep(d, vals=self._vals_with(pandas.NA))
         assert result == {"a": 1}
 
-    def test_pandas_nat_top_level(self):
+    def test_pandas_nat_top_level(self, pandas):
         d = {"a": 1, "b": pandas.NaT}
         result = dict_sweep(d, vals=self._vals_with(pandas.NaT))
         assert result == {"a": 1}
 
-    def test_numpy_nan_top_level(self):
+    def test_numpy_nan_top_level(self, numpy):
         d = {"a": 1, "b": numpy.nan}
         result = dict_sweep(d, vals=self._vals_with(float("nan")))
         assert result == {"a": 1}
 
-    def test_pandas_na_in_list(self):
+    def test_pandas_na_in_list(self, pandas):
         d = {"a": [1, pandas.NA, 2]}
         result = dict_sweep(d, vals=self._vals_with(pandas.NA))
         assert result == {"a": [1, 2]}
 
-    def test_pandas_nat_in_list(self):
+    def test_pandas_nat_in_list(self, pandas):
         d = {"a": [1, pandas.NaT, 2]}
         result = dict_sweep(d, vals=self._vals_with(pandas.NaT))
         assert result == {"a": [1, 2]}
 
-    def test_numpy_nan_in_list(self):
+    def test_numpy_nan_in_list(self, numpy):
         d = {"a": [1, numpy.nan, 2]}
         result = dict_sweep(d, vals=self._vals_with(float("nan")))
         assert result == {"a": [1, 2]}
 
-    def test_pandas_na_in_nested_dict(self):
+    def test_pandas_na_in_nested_dict(self, pandas):
         d = {"a": {"b": pandas.NA, "c": 1}}
         result = dict_sweep(d, vals=self._vals_with(pandas.NA))
         assert result == {"a": {"c": 1}}
 
-    def test_pandas_na_in_list_with_remove_invalid_list(self):
+    def test_pandas_na_in_list_with_remove_invalid_list(self, pandas):
         d = {"a": [pandas.NA, pandas.NaT, "valid"]}
         result = dict_sweep(d, vals=self._vals_with(pandas.NA, pandas.NaT), remove_invalid_list=True)
         assert result == {"a": ["valid"]}
 
-    def test_all_real_nan_types_removed(self):
+    def test_all_real_nan_types_removed(self, pandas, numpy):
         d = {"a": numpy.nan, "b": pandas.NA, "c": pandas.NaT, "d": "keep"}
         result = dict_sweep(d, vals=self._vals_with(float("nan"), pandas.NA, pandas.NaT))
         assert result == {"d": "keep"}
 
-    def test_real_nan_kept_by_default(self):
+    def test_real_nan_kept_by_default(self, pandas, numpy):
         """Without opting in, real NaN types are preserved."""
         d = {"a": numpy.nan, "b": pandas.NA, "c": pandas.NaT, "d": "keep"}
         result = dict_sweep(d)

--- a/tests/utils/test_dataload.py
+++ b/tests/utils/test_dataload.py
@@ -1,0 +1,249 @@
+"""
+Tests for dict_sweep and _is_nan in biothings.utils.dataload,
+specifically the handling of NaN-like values.
+"""
+
+import math
+
+import pytest
+
+from biothings.utils.dataload import _is_nan, dict_sweep
+
+# ---------------------------------------------------------------------------
+# Fake pandas-like NA / NaT types for testing without importing pandas
+# ---------------------------------------------------------------------------
+
+class NAType:
+    """Mimics pandas.NA (pandas.core.arrays.masked.NAType)."""
+    def __bool__(self):
+        raise TypeError("boolean value of NA is ambiguous")
+
+    def __eq__(self, other):
+        raise TypeError("boolean value of NA is ambiguous")
+
+    def __hash__(self):
+        return 0
+
+    def __repr__(self):
+        return "<NA>"
+
+
+class NaTType:
+    """Mimics pandas.NaT (pandas._libs.tslibs.nattype.NaTType)."""
+    def __bool__(self):
+        raise TypeError("boolean value of NaT is ambiguous")
+
+    def __eq__(self, other):
+        raise TypeError("boolean value of NaT is ambiguous")
+
+    def __hash__(self):
+        return 0
+
+    def __repr__(self):
+        return "NaT"
+
+
+_NA = NAType()
+_NaT = NaTType()
+
+
+# ---------------------------------------------------------------------------
+# _is_nan helper tests
+# ---------------------------------------------------------------------------
+
+class TestIsNan:
+    def test_float_nan(self):
+        assert _is_nan(float("nan")) is True
+
+    def test_na_type(self):
+        assert _is_nan(_NA) is True
+
+    def test_nat_type(self):
+        assert _is_nan(_NaT) is True
+
+    def test_regular_values_are_not_nan(self):
+        for val in [0, 1, -1, "", "hello", None, [], {}, 0.0, 1.5, True, False]:
+            assert _is_nan(val) is False, f"_is_nan should be False for {val!r}"
+
+
+# ---------------------------------------------------------------------------
+# dict_sweep tests — NaN-like values at top level
+# ---------------------------------------------------------------------------
+
+class TestDictSweepNanTopLevel:
+    def test_float_nan_removed(self):
+        d = {"a": 1, "b": float("nan")}
+        result = dict_sweep(d)
+        assert result == {"a": 1}
+
+    def test_pandas_na_removed(self):
+        d = {"a": 1, "b": _NA}
+        result = dict_sweep(d)
+        assert result == {"a": 1}
+
+    def test_pandas_nat_removed(self):
+        d = {"a": 1, "b": _NaT}
+        result = dict_sweep(d)
+        assert result == {"a": 1}
+
+    def test_multiple_nan_types_removed(self):
+        d = {"a": float("nan"), "b": _NA, "c": _NaT, "d": "keep"}
+        result = dict_sweep(d)
+        assert result == {"d": "keep"}
+
+
+# ---------------------------------------------------------------------------
+# dict_sweep tests — NaN-like values inside lists
+# ---------------------------------------------------------------------------
+
+class TestDictSweepNanInList:
+    def test_nan_removed_from_list(self):
+        d = {"a": [1, float("nan"), 2]}
+        result = dict_sweep(d)
+        assert result == {"a": [1, 2]}
+
+    def test_na_removed_from_list(self):
+        d = {"a": [1, _NA, 2]}
+        result = dict_sweep(d)
+        assert result == {"a": [1, 2]}
+
+    def test_nat_removed_from_list(self):
+        d = {"a": [1, _NaT, 2]}
+        result = dict_sweep(d)
+        assert result == {"a": [1, 2]}
+
+    def test_list_becomes_empty_after_nan_removal(self):
+        d = {"a": [float("nan")]}
+        result = dict_sweep(d)
+        assert "a" not in result
+
+    def test_nan_in_list_with_remove_invalid_list(self):
+        d = {"a": [float("nan"), _NA, "valid"]}
+        result = dict_sweep(d, remove_invalid_list=True)
+        assert result == {"a": ["valid"]}
+
+    def test_all_nan_list_removed_with_remove_invalid_list(self):
+        d = {"a": [float("nan"), _NA, _NaT]}
+        result = dict_sweep(d, remove_invalid_list=True)
+        assert "a" not in result
+
+
+# ---------------------------------------------------------------------------
+# dict_sweep tests — NaN-like values in nested dicts
+# ---------------------------------------------------------------------------
+
+class TestDictSweepNanNested:
+    def test_nan_in_nested_dict(self):
+        d = {"a": {"b": float("nan"), "c": 1}}
+        result = dict_sweep(d)
+        assert result == {"a": {"c": 1}}
+
+    def test_na_in_nested_dict(self):
+        d = {"a": {"b": _NA, "c": 1}}
+        result = dict_sweep(d)
+        assert result == {"a": {"c": 1}}
+
+    def test_nested_dict_removed_when_empty_after_sweep(self):
+        d = {"a": {"b": float("nan")}}
+        result = dict_sweep(d)
+        assert "a" not in result
+
+    def test_nan_in_list_of_dicts(self):
+        d = {"a": [{"x": float("nan"), "y": 1}, {"x": _NA, "y": 2}]}
+        result = dict_sweep(d)
+        assert result == {"a": [{"y": 1}, {"y": 2}]}
+
+
+# ---------------------------------------------------------------------------
+# dict_sweep tests — default vals still work
+# ---------------------------------------------------------------------------
+
+class TestDictSweepDefaultBehavior:
+    def test_default_vals_still_removed(self):
+        d = {"a": ".", "b": "-", "c": "", "d": "keep"}
+        result = dict_sweep(d)
+        assert result == {"d": "keep"}
+
+    def test_normal_values_kept(self):
+        d = {"a": 1, "b": "hello", "c": [1, 2], "d": {"nested": True}}
+        result = dict_sweep(d)
+        assert result == {"a": 1, "b": "hello", "c": [1, 2], "d": {"nested": True}}
+
+    def test_mixed_nan_and_default_vals(self):
+        d = {"a": float("nan"), "b": ".", "c": _NA, "d": "keep", "e": ""}
+        result = dict_sweep(d)
+        assert result == {"d": "keep"}
+
+
+# ---------------------------------------------------------------------------
+# Tests using real pandas and numpy types
+# ---------------------------------------------------------------------------
+
+pandas = pytest.importorskip("pandas")
+numpy = pytest.importorskip("numpy")
+
+
+class TestIsNanRealTypes:
+    def test_numpy_nan(self):
+        assert _is_nan(numpy.nan) is True
+
+    def test_pandas_na(self):
+        assert _is_nan(pandas.NA) is True
+
+    def test_pandas_nat(self):
+        assert _is_nan(pandas.NaT) is True
+
+    def test_numpy_float_nan(self):
+        assert _is_nan(numpy.float64("nan")) is True
+
+
+class TestDictSweepRealPandasNA:
+    def test_pandas_na_top_level(self):
+        d = {"a": 1, "b": pandas.NA}
+        result = dict_sweep(d)
+        assert result == {"a": 1}
+
+    def test_pandas_nat_top_level(self):
+        d = {"a": 1, "b": pandas.NaT}
+        result = dict_sweep(d)
+        assert result == {"a": 1}
+
+    def test_numpy_nan_top_level(self):
+        d = {"a": 1, "b": numpy.nan}
+        result = dict_sweep(d)
+        assert result == {"a": 1}
+
+    def test_pandas_na_in_list(self):
+        d = {"a": [1, pandas.NA, 2]}
+        result = dict_sweep(d)
+        assert result == {"a": [1, 2]}
+
+    def test_pandas_nat_in_list(self):
+        d = {"a": [1, pandas.NaT, 2]}
+        result = dict_sweep(d)
+        assert result == {"a": [1, 2]}
+
+    def test_numpy_nan_in_list(self):
+        d = {"a": [1, numpy.nan, 2]}
+        result = dict_sweep(d)
+        assert result == {"a": [1, 2]}
+
+    def test_pandas_na_in_nested_dict(self):
+        d = {"a": {"b": pandas.NA, "c": 1}}
+        result = dict_sweep(d)
+        assert result == {"a": {"c": 1}}
+
+    def test_pandas_na_in_list_with_remove_invalid_list(self):
+        d = {"a": [pandas.NA, pandas.NaT, "valid"]}
+        result = dict_sweep(d, remove_invalid_list=True)
+        assert result == {"a": ["valid"]}
+
+    def test_all_real_nan_types_removed(self):
+        d = {"a": numpy.nan, "b": pandas.NA, "c": pandas.NaT, "d": "keep"}
+        result = dict_sweep(d)
+        assert result == {"d": "keep"}
+
+    def test_mixed_real_and_default_vals(self):
+        d = {"a": pandas.NA, "b": ".", "c": numpy.nan, "d": "keep", "e": pandas.NaT}
+        result = dict_sweep(d)
+        assert result == {"d": "keep"}


### PR DESCRIPTION
`dict_sweep` comparisons `(val == any of vals)` can raise `ValueError` if val is pandas.NA or similar, because pandas treats comparisons with missing values as invalid instead of returning False.

Changes:
- Add _is_nan() helper that detects float NaN, pandas.NA, and pandas.NaT via math.isnan and duck-typing (__class__.__name__) without importing numpy or pandas
- Call _is_nan() before val in vals at every level in dict_sweep (top-level values, list items, and nested dicts)
- Replace list.remove() with filter-and-rebuild to avoid __eq__ calls on NaN-like values during list mutation
- Add comprehensive tests covering mock and real pandas/numpy types