### PR TITLE
fix(query): replace risky assertions with explicit user-input validation

### DIFF
--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -707,8 +707,12 @@ class ESQueryBuilder:
         Override this to customize default match query.
         By default it implements a multi_match query.
         """
-        assert isinstance(q, (str, int, float, bool))
-        assert isinstance(scopes, (list, tuple, str)) and scopes
+        if not isinstance(q, (str, int, float, bool)):
+            raise ValueError("Query parameter 'q' must be a primitive type (string, integer, float, or boolean).")        
+
+        if not isinstance(scopes, (list, tuple, str)) or not scopes:
+            raise ValueError("Parameter 'scopes' must be a non-empty list, tuple, or string.")
+        
         _params = dict(query=q, fields=scopes, operator="AND", lenient=True)
         if options.analyzer:
             _params["analyzer"] = options.analyzer

--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -712,7 +712,7 @@ class ESQueryBuilder:
 
         if not isinstance(scopes, (list, tuple, str)) or not scopes:
             raise ValueError("Parameter 'scopes' must be a non-empty list, tuple, or string.")
-        
+
         _params = dict(query=q, fields=scopes, operator="AND", lenient=True)
         if options.analyzer:
             _params["analyzer"] = options.analyzer

--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -708,7 +708,7 @@ class ESQueryBuilder:
         By default it implements a multi_match query.
         """
         if not isinstance(q, (str, int, float, bool)):
-            raise ValueError("Query parameter 'q' must be a primitive type (string, integer, float, or boolean).")        
+            raise ValueError("Query parameter 'q' must be a primitive type (string, integer, float, or boolean).")
 
         if not isinstance(scopes, (list, tuple, str)) or not scopes:
             raise ValueError("Parameter 'scopes' must be a non-empty list, tuple, or string.")

--- a/tests/web/analytics/test_channels.py
+++ b/tests/web/analytics/test_channels.py
@@ -1,13 +1,23 @@
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, call, patch
 
 import aiohttp
 import pytest
-from aioresponses import aioresponses
 
 from biothings.utils import serializer
 from biothings.web.analytics.channels import GA4Channel, SlackChannel
 from biothings.web.analytics.events import GAEvent, Message
+
+
+class MockClientResponse:
+    def __init__(self, status):
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
 
 
 @pytest.mark.asyncio
@@ -18,18 +28,19 @@ async def test_send_Slack():
 
     assert await channel.handles(message)
 
-    with patch("aiohttp.ClientSession.post") as mock_post, patch("certifi.where") as mock_certifi, patch(
-        "ssl.create_default_context"
+    with patch(
+        "biothings.web.analytics.channels.aiohttp.ClientSession.post", return_value=MockClientResponse(200)
+    ) as mock_post, patch("biothings.web.analytics.channels.certifi.where") as mock_certifi, patch(
+        "biothings.web.analytics.channels.ssl.create_default_context"
     ) as mock_ssl_context:
 
         # Mocking the post request response and certifi.where
-        mock_post.return_value.__aenter__.return_value.status = 200
         mock_certifi.return_value = "/path/to/fake_cert.pem"  # Any dummy path
         mock_ssl_context.return_value = None  # Return None to bypass actual SSL context
 
-        with aioresponses() as responses:
-            responses.post(url, status=200)
-            await channel.send(message)
+        await channel.send(message)
+
+    mock_post.assert_called_once_with(url, json=message.to_slack_payload(), ssl=None)
 
 
 @pytest.mark.asyncio
@@ -52,12 +63,22 @@ async def test_send_GA4():
     channel = GA4Channel("GA4_MEASUREMENT_ID", "GA4_API_SECRET", 1)
     assert await channel.handles(event)
 
-    with aioresponses() as responses:
-        # Mock the URL to return a 200 OK response
-        responses.post(channel.url, status=200)
+    expected_events = event.to_GA4_payload(channel.measurement_id, channel.uid_version)
+    expected_data = serializer.to_json(
+        {
+            "client_id": "12345",
+            "user_id": "67890",
+            "events": expected_events,
+        },
+        return_bytes=True,
+    )
 
-        # If the function completes without raising an exception, the test will pass
+    with patch(
+        "biothings.web.analytics.channels.aiohttp.ClientSession.post", return_value=MockClientResponse(200)
+    ) as mock_post, patch.object(event, "_cid", side_effect=[12345, 67890]):
         await channel.send(event)
+
+    mock_post.assert_called_once_with(channel.url, data=expected_data)
 
 
 @pytest.mark.asyncio
@@ -68,15 +89,15 @@ async def test_send_GA4_request_retries():
     data = serializer.to_json({"test": "data"}, return_bytes=True)
 
     async with aiohttp.ClientSession() as session:
-        with aioresponses() as responses:
-            # Mock the URL to return HTTP 500 on the first call and HTTP 200 on the second call
-            responses.post(url, status=500)
-            responses.post(url, status=200)
-
+        with patch(
+            "biothings.web.analytics.channels.aiohttp.ClientSession.post",
+            side_effect=[MockClientResponse(500), MockClientResponse(200)],
+        ) as mock_post, patch("biothings.web.analytics.channels.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             await channel.send_request(session, url, data)
 
-            assert responses._responses[0].status == 500
-            assert responses._responses[1].status == 200
+    assert mock_post.call_count == channel.max_retries + 1
+    mock_post.assert_has_calls([call(url, data=data), call(url, data=data)])
+    mock_sleep.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -86,13 +107,12 @@ async def test_send_GA4_request_max_retries():
     data = serializer.to_json({"test": "data"}, return_bytes=True)
 
     async with aiohttp.ClientSession() as session:
-        with aioresponses() as responses:
-            # Mock the URL to always return a 500 response
-            responses.post(url, status=500)
-            responses.post(url, status=500)
-
+        with patch(
+            "biothings.web.analytics.channels.aiohttp.ClientSession.post",
+            side_effect=[MockClientResponse(500) for _ in range(channel.max_retries + 1)],
+        ) as mock_post, patch("biothings.web.analytics.channels.asyncio.sleep", new_callable=AsyncMock):
             with pytest.raises(Exception, match="GA4Channel: Maximum retries reached. Unable to complete request."):
                 await channel.send_request(session, url, data)
 
-            # Ensure the post method was called max_retries + 1 times
-            assert len(responses._responses) == channel.max_retries + 1
+    assert mock_post.call_count == channel.max_retries + 1
+    mock_post.assert_has_calls([call(url, data=data) for _ in range(channel.max_retries + 1)])


### PR DESCRIPTION
Fixes an unhandled AssertionError that crashes the POST `/v3/query` endpoint with a `500` error when users pass unexpected data types (like a nested dictionary) into the `q` or `scopes` parameters.