### PR TITLE
Fix GA4 channel tests without aioresponses internals

### DIFF
--- a/tests/web/analytics/test_channels.py
+++ b/tests/web/analytics/test_channels.py
@@ -1,13 +1,23 @@
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, call, patch
 
 import aiohttp
 import pytest
-from aioresponses import aioresponses
 
 from biothings.utils import serializer
 from biothings.web.analytics.channels import GA4Channel, SlackChannel
 from biothings.web.analytics.events import GAEvent, Message
+
+
+class MockClientResponse:
+    def __init__(self, status):
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
 
 
 @pytest.mark.asyncio
@@ -18,18 +28,19 @@ async def test_send_Slack():
 
     assert await channel.handles(message)
 
-    with patch("aiohttp.ClientSession.post") as mock_post, patch("certifi.where") as mock_certifi, patch(
-        "ssl.create_default_context"
+    with patch(
+        "biothings.web.analytics.channels.aiohttp.ClientSession.post", return_value=MockClientResponse(200)
+    ) as mock_post, patch("biothings.web.analytics.channels.certifi.where") as mock_certifi, patch(
+        "biothings.web.analytics.channels.ssl.create_default_context"
     ) as mock_ssl_context:
 
         # Mocking the post request response and certifi.where
-        mock_post.return_value.__aenter__.return_value.status = 200
         mock_certifi.return_value = "/path/to/fake_cert.pem"  # Any dummy path
         mock_ssl_context.return_value = None  # Return None to bypass actual SSL context
 
-        with aioresponses() as responses:
-            responses.post(url, status=200)
-            await channel.send(message)
+        await channel.send(message)
+
+    mock_post.assert_called_once_with(url, json=message.to_slack_payload(), ssl=None)
 
 
 @pytest.mark.asyncio
@@ -52,12 +63,22 @@ async def test_send_GA4():
     channel = GA4Channel("GA4_MEASUREMENT_ID", "GA4_API_SECRET", 1)
     assert await channel.handles(event)
 
-    with aioresponses() as responses:
-        # Mock the URL to return a 200 OK response
-        responses.post(channel.url, status=200)
+    expected_events = event.to_GA4_payload(channel.measurement_id, channel.uid_version)
+    expected_data = serializer.to_json(
+        {
+            "client_id": "12345",
+            "user_id": "67890",
+            "events": expected_events,
+        },
+        return_bytes=True,
+    )
 
-        # If the function completes without raising an exception, the test will pass
+    with patch(
+        "biothings.web.analytics.channels.aiohttp.ClientSession.post", return_value=MockClientResponse(200)
+    ) as mock_post, patch.object(event, "_cid", side_effect=[12345, 67890]):
         await channel.send(event)
+
+    mock_post.assert_called_once_with(channel.url, data=expected_data)
 
 
 @pytest.mark.asyncio
@@ -68,15 +89,15 @@ async def test_send_GA4_request_retries():
     data = serializer.to_json({"test": "data"}, return_bytes=True)
 
     async with aiohttp.ClientSession() as session:
-        with aioresponses() as responses:
-            # Mock the URL to return HTTP 500 on the first call and HTTP 200 on the second call
-            responses.post(url, status=500)
-            responses.post(url, status=200)
-
+        with patch(
+            "biothings.web.analytics.channels.aiohttp.ClientSession.post",
+            side_effect=[MockClientResponse(500), MockClientResponse(200)],
+        ) as mock_post, patch("biothings.web.analytics.channels.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             await channel.send_request(session, url, data)
 
-            assert responses._responses[0].status == 500
-            assert responses._responses[1].status == 200
+    assert mock_post.call_count == channel.max_retries + 1
+    mock_post.assert_has_calls([call(url, data=data), call(url, data=data)])
+    mock_sleep.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -86,13 +107,12 @@ async def test_send_GA4_request_max_retries():
     data = serializer.to_json({"test": "data"}, return_bytes=True)
 
     async with aiohttp.ClientSession() as session:
-        with aioresponses() as responses:
-            # Mock the URL to always return a 500 response
-            responses.post(url, status=500)
-            responses.post(url, status=500)
-
+        with patch(
+            "biothings.web.analytics.channels.aiohttp.ClientSession.post",
+            side_effect=[MockClientResponse(500) for _ in range(channel.max_retries + 1)],
+        ) as mock_post, patch("biothings.web.analytics.channels.asyncio.sleep", new_callable=AsyncMock):
             with pytest.raises(Exception, match="GA4Channel: Maximum retries reached. Unable to complete request."):
                 await channel.send_request(session, url, data)
 
-            # Ensure the post method was called max_retries + 1 times
-            assert len(responses._responses) == channel.max_retries + 1
+    assert mock_post.call_count == channel.max_retries + 1
+    mock_post.assert_has_calls([call(url, data=data) for _ in range(channel.max_retries + 1)])


### PR DESCRIPTION
## Summary

This updates the analytics channel tests to avoid relying on `aioresponses` response construction, which is incompatible with newer `aiohttp` versions requiring additional `ClientResponse` constructor arguments.

The GA4 tests now mock `aiohttp.ClientSession.post()` directly with a minimal async response context manager exposing only the `status` attribute used by production code.

## Changes

- Remove `aioresponses` usage from GA4 channel tests.
- Add a lightweight fake async response context manager.
- Patch `biothings.web.analytics.channels.aiohttp.ClientSession.post`.
- Mock `asyncio.sleep` in retry tests to avoid real backoff delays.
- Assert POST call counts and request arguments directly.
- Remove an unnecessary `aioresponses()` wrapper from the Slack test.

## Verification

```bash
.venv/bin/pytest tests/web/analytics/test_channels.py -q