### PR TITLE
Defer ready index registration until post-index completes

### DIFF
--- a/biothings/hub/dataindex/indexer.py
+++ b/biothings/hub/dataindex/indexer.py
@@ -361,6 +361,7 @@ class Indexer:
         """
 
         steps = kwargs.pop("steps", ("pre", "index", "post"))
+        defer_index_registration = kwargs.pop("_defer_index_registration", False)
         batch_size = kwargs.setdefault("batch_size", 10000)
         # mode = kwargs.setdefault("mode", "index")
         kwargs.setdefault("mode", "index")
@@ -378,9 +379,12 @@ class Indexer:
         # can be sent to elasticsearch within one request, making it
         # inefficient, amplifying the scheduling overhead.
 
+        ordered_steps = tuple(Step.order(steps))
+        defer_index_registration = defer_index_registration or ("index" in ordered_steps and "post" in ordered_steps)
+
         x = IndexerCumulativeResult()
-        for step in Step.order(steps):
-            step = Step.dispatch(step)(self)
+        for step_name in ordered_steps:
+            step = Step.dispatch(step_name)(self)
             self.logger.info(step)
             step.state.started()
             try:
@@ -395,7 +399,10 @@ class Indexer:
                 merge(x.data, dx.data)
                 self.logger.info(dx)
                 self.logger.info(x)
-                step.state.succeed(x.data)
+                if step.name == "index" and defer_index_registration:
+                    step.state.succeed_without_registration()
+                else:
+                    step.state.succeed(x.data)
 
         return x
 
@@ -571,10 +578,13 @@ class ColdHotIndexer:
         **kwargs,
     ):
         result = []
+        ordered_steps = tuple(Step.order(steps))
+        defer_index_registration = "index" in ordered_steps and "post" in ordered_steps
 
         cold_task = self.cold.index(
             job_manager,
-            steps=set(Step.order(steps)) & {"pre", "index"},
+            steps=set(ordered_steps) & {"pre", "index"},
+            _defer_index_registration=defer_index_registration,
             batch_size=batch_size,
             ids=ids,
             mode=mode,
@@ -583,7 +593,7 @@ class ColdHotIndexer:
 
         hot_task = self.hot.index(
             job_manager,
-            steps=set(Step.order(steps)) & {"index", "post"},
+            steps=set(ordered_steps) & {"index", "post"},
             batch_size=batch_size,
             ids=ids,
             mode="merge",

--- a/biothings/hub/dataindex/indexer_registrar.py
+++ b/biothings/hub/dataindex/indexer_registrar.py
@@ -79,6 +79,14 @@ class IndexJobStateRegistrar:
 
         self._done(func)
 
+    def succeed_without_registration(self):
+        def func(job, delta_build):
+            job["status"] = "success"
+            # Do not leave a stale ready record visible while a later step is still required.
+            delta_build["index"] = {self.index_name: {"__REMOVE__": True}}
+
+        self._done(func)
+
     def _done(self, func):
         self.stage.at(Stage.STARTED)
         self.stage = Stage.DONE

--- a/tests/hub/dataindex/test_indexer_lifecycle.py
+++ b/tests/hub/dataindex/test_indexer_lifecycle.py
@@ -1,0 +1,260 @@
+import asyncio
+import copy
+import importlib
+
+import pytest
+
+
+class FakeSrcBuildCollection:
+    def __init__(self, docs):
+        self.docs = {doc["_id"]: copy.deepcopy(doc) for doc in docs}
+
+    def find(self, query=None):
+        return [copy.deepcopy(doc) for doc in self.docs.values() if self._matches(doc, query or {})]
+
+    def find_one(self, query):
+        for doc in self.docs.values():
+            if self._matches(doc, query):
+                return copy.deepcopy(doc)
+        return None
+
+    def replace_one(self, query, doc):
+        existing = self.find_one(query)
+        assert existing, f"document not found: {query}"
+        self.docs[existing["_id"]] = copy.deepcopy(doc)
+
+    def update(self, query, update):
+        doc = self._find_stored(query)
+        assert doc, f"document not found: {query}"
+        for op, changes in update.items():
+            if op == "$push":
+                for path, value in changes.items():
+                    parent, key = self._ensure_parent(doc, path)
+                    parent.setdefault(key, []).append(copy.deepcopy(value))
+            elif op == "$addToSet":
+                for path, value in changes.items():
+                    parent, key = self._ensure_parent(doc, path)
+                    values = parent.setdefault(key, [])
+                    if value not in values:
+                        values.append(copy.deepcopy(value))
+            elif op == "$pull":
+                for path, value in changes.items():
+                    parent, key = self._ensure_parent(doc, path)
+                    parent[key] = [item for item in parent.get(key, []) if item != value]
+            elif op == "$unset":
+                for path in changes:
+                    parent, key = self._ensure_parent(doc, path)
+                    parent.pop(key, None)
+            else:
+                raise NotImplementedError(op)
+
+    def _find_stored(self, query):
+        for doc in self.docs.values():
+            if self._matches(doc, query):
+                return doc
+        return None
+
+    def _matches(self, doc, query):
+        return all(self._get(doc, path) == expected for path, expected in query.items())
+
+    def _get(self, doc, path):
+        value = doc
+        for part in path.split("."):
+            if not isinstance(value, dict) or part not in value:
+                return None
+            value = value[part]
+        return value
+
+    def _ensure_parent(self, doc, path):
+        value = doc
+        parts = path.split(".")
+        for part in parts[:-1]:
+            value = value.setdefault(part, {})
+        return value, parts[-1]
+
+
+def make_build_doc(index=None):
+    doc = {
+        "_id": "test_build",
+        "target_name": "test_build",
+        "build_config": {
+            "name": "test",
+            "doc_type": "doc",
+        },
+        "mapping": {},
+        "_meta": {},
+        "jobs": [],
+    }
+    if index is not None:
+        doc["index"] = index
+    return doc
+
+
+@pytest.fixture
+def dataindex_modules(root_configuration, tmp_path):
+    root_configuration.override(
+        {
+            "__file__": str(tmp_path / "test_config.py"),
+            "HUB_DB_BACKEND": {
+                "module": "biothings.utils.sqlite3",
+                "sqlite_db_folder": str(tmp_path),
+            },
+            "DATA_HUB_DB_DATABASE": "indexer_lifecycle_hubdb",
+        }
+    )
+
+    importlib.import_module("biothings.hub")._config_for_app(root_configuration)
+    indexer_module = importlib.import_module("biothings.hub.dataindex.indexer")
+    snapshooter_module = importlib.import_module("biothings.hub.dataindex.snapshooter")
+
+    yield indexer_module, snapshooter_module
+
+    root_configuration.reset()
+
+
+def make_lifecycle_indexer_class(indexer_module):
+    class LifecycleIndexer(indexer_module.Indexer):
+        async def pre_index(self, *args, mode, **kwargs):
+            return {
+                "__REPLACE__": True,
+                "host": self.es_client_args.get("hosts"),
+                "environment": self.env_name,
+            }
+
+        async def do_index(self, job_manager, batch_size, ids, mode, **kwargs):
+            return {
+                "count": 2,
+                "created_at": "index-step",
+            }
+
+        async def post_index(self, *args, **kwargs):
+            return {
+                "post": {
+                    "embeddings": "done",
+                    "force_merge": "done",
+                }
+            }
+
+    return LifecycleIndexer
+
+
+def make_indexer(collection, indexer_class):
+    build_doc = collection.find_one({"_id": "test_build"})
+    return indexer_class(
+        build_doc,
+        {
+            "name": "local",
+            "args": {
+                "hosts": "http://localhost:9200",
+            },
+        },
+        "test_index",
+    )
+
+
+def test_full_index_flow_registers_ready_index_only_after_post(monkeypatch, dataindex_modules):
+    indexer_module, _ = dataindex_modules
+    lifecycle_indexer = make_lifecycle_indexer_class(indexer_module)
+    collection = FakeSrcBuildCollection([make_build_doc()])
+    monkeypatch.setattr(indexer_module, "get_src_build", lambda: collection)
+    observations = []
+
+    class ObservingIndexer(lifecycle_indexer):
+        async def post_index(self, *args, **kwargs):
+            build_doc = collection.find_one({"_id": self.build_name})
+            observations.append(copy.deepcopy(build_doc.get("index", {})))
+            return await super().post_index(*args, **kwargs)
+
+    indexer = make_indexer(collection, ObservingIndexer)
+
+    asyncio.run(indexer.index(object(), steps=("pre", "index", "post")))
+
+    assert "test_index" not in observations[0]
+    build_doc = collection.find_one({"_id": "test_build"})
+    assert build_doc["index"]["test_index"] == {
+        "host": "http://localhost:9200",
+        "environment": "local",
+        "count": 2,
+        "created_at": "index-step",
+        "post": {
+            "embeddings": "done",
+            "force_merge": "done",
+        },
+    }
+
+
+def test_index_without_post_registers_ready_index_after_index(monkeypatch, dataindex_modules):
+    indexer_module, _ = dataindex_modules
+    lifecycle_indexer = make_lifecycle_indexer_class(indexer_module)
+    collection = FakeSrcBuildCollection([make_build_doc()])
+    monkeypatch.setattr(indexer_module, "get_src_build", lambda: collection)
+
+    indexer = make_indexer(collection, lifecycle_indexer)
+
+    asyncio.run(indexer.index(object(), steps=("pre", "index")))
+
+    build_doc = collection.find_one({"_id": "test_build"})
+    assert build_doc["index"]["test_index"] == {
+        "host": "http://localhost:9200",
+        "environment": "local",
+        "count": 2,
+        "created_at": "index-step",
+    }
+
+
+def test_post_failure_after_index_success_does_not_expose_ready_index(monkeypatch, dataindex_modules):
+    indexer_module, _ = dataindex_modules
+    lifecycle_indexer = make_lifecycle_indexer_class(indexer_module)
+    collection = FakeSrcBuildCollection(
+        [
+            make_build_doc(
+                index={
+                    "test_index": {
+                        "environment": "local",
+                        "count": 99,
+                    }
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr(indexer_module, "get_src_build", lambda: collection)
+
+    class FailingPostIndexer(lifecycle_indexer):
+        async def post_index(self, *args, **kwargs):
+            raise RuntimeError("force merge failed")
+
+    indexer = make_indexer(collection, FailingPostIndexer)
+
+    with pytest.raises(RuntimeError, match="force merge failed"):
+        asyncio.run(indexer.index(object(), steps=("pre", "index", "post")))
+
+    build_doc = collection.find_one({"_id": "test_build"})
+    assert "test_index" not in build_doc.get("index", {})
+    assert build_doc["jobs"][-2]["step"] == "index"
+    assert build_doc["jobs"][-2]["status"] == "success"
+    assert build_doc["jobs"][-1]["step"] == "post-index"
+    assert build_doc["jobs"][-1]["status"] == "failed"
+    assert build_doc["jobs"][-1]["err"] == "force merge failed"
+
+
+def test_snapshot_lookup_cannot_find_index_until_post_succeeds(monkeypatch, dataindex_modules):
+    indexer_module, snapshooter = dataindex_modules
+    lifecycle_indexer = make_lifecycle_indexer_class(indexer_module)
+    collection = FakeSrcBuildCollection([make_build_doc()])
+    monkeypatch.setattr(indexer_module, "get_src_build", lambda: collection)
+    monkeypatch.setattr(snapshooter, "get_src_build", lambda: collection)
+    snapshot_env = object.__new__(snapshooter.SnapshotEnv)
+    snapshot_env.idxenv = "local"
+
+    class SnapshotLookupIndexer(lifecycle_indexer):
+        async def post_index(self, *args, **kwargs):
+            with pytest.raises(ValueError, match="Not a hub-managed index"):
+                snapshooter.SnapshotEnv._doc(snapshot_env, "test_index")
+            return await super().post_index(*args, **kwargs)
+
+    indexer = make_indexer(collection, SnapshotLookupIndexer)
+
+    asyncio.run(indexer.index(object(), steps=("pre", "index", "post")))
+
+    build_doc = snapshooter.SnapshotEnv._doc(snapshot_env, "test_index")
+    assert build_doc["_id"] == "test_build"


### PR DESCRIPTION
- Defers `src_build.index.<index_name>` registration when an index flow includes both `index` and `post`
- Registers the cumulative index + post metadata only after the post step succeeds
- Preserves current behavior for `pre,index` flows and post-only runs
- Prevents snapshot/autobuild lookup from seeing an index while post-index work is still running