### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,18 @@
 
+v1.1.1 (2026/06/18)
+    biothings.hub improvements:
+        - Fixed index lifecycle registration so indexes are only marked ready after post-index steps complete. ([#449](https://github.com/biothings/biothings.api/pull/449))
+        - Fixed DataTransform nested lookup handling for lists of dictionaries and one-to-many API lookup results.
+
+    biothings.web improvements:
+        - Fixed GA4 analytics request context handling so referer and page location are propagated to custom events. ([#450](https://github.com/biothings/biothings.api/pull/450))
+        - Replaced risky Elasticsearch query assertions with explicit user-input validation. ([#447](https://github.com/biothings/biothings.api/pull/447))
+
+    Misc improvements:
+        - Fixed GA4 analytics channel tests for newer aiohttp behavior without relying on aioresponses internals. ([#448](https://github.com/biothings/biothings.api/pull/448))
+        - Updated the Elasticsearch dependency floor to 8.18+ for supported Python versions.
+
+
 v1.1.0 (2026/05/27)
     Highlights:
         - Added Python 3.14 support and dropped Python 3.8 support.

--- a/biothings/__init__.py
+++ b/biothings/__init__.py
@@ -8,7 +8,7 @@ class _version_info(NamedTuple):
     micro: int
 
 
-version_info = _version_info(1, 1, 0)
+version_info = _version_info(1, 1, 1)
 __version__ = ".".join(map(str, version_info))
 
 

--- a/biothings/hub/dataindex/indexer.py
+++ b/biothings/hub/dataindex/indexer.py
@@ -361,6 +361,7 @@ class Indexer:
         """
 
         steps = kwargs.pop("steps", ("pre", "index", "post"))
+        defer_index_registration = kwargs.pop("_defer_index_registration", False)
         batch_size = kwargs.setdefault("batch_size", 10000)
         # mode = kwargs.setdefault("mode", "index")
         kwargs.setdefault("mode", "index")
@@ -378,9 +379,12 @@ class Indexer:
         # can be sent to elasticsearch within one request, making it
         # inefficient, amplifying the scheduling overhead.
 
+        ordered_steps = tuple(Step.order(steps))
+        defer_index_registration = defer_index_registration or ("index" in ordered_steps and "post" in ordered_steps)
+
         x = IndexerCumulativeResult()
-        for step in Step.order(steps):
-            step = Step.dispatch(step)(self)
+        for step_name in ordered_steps:
+            step = Step.dispatch(step_name)(self)
             self.logger.info(step)
             step.state.started()
             try:
@@ -395,7 +399,10 @@ class Indexer:
                 merge(x.data, dx.data)
                 self.logger.info(dx)
                 self.logger.info(x)
-                step.state.succeed(x.data)
+                if step.name == "index" and defer_index_registration:
+                    step.state.succeed_without_registration()
+                else:
+                    step.state.succeed(x.data)
 
         return x
 
@@ -571,10 +578,13 @@ class ColdHotIndexer:
         **kwargs,
     ):
         result = []
+        ordered_steps = tuple(Step.order(steps))
+        defer_index_registration = "index" in ordered_steps and "post" in ordered_steps
 
         cold_task = self.cold.index(
             job_manager,
-            steps=set(Step.order(steps)) & {"pre", "index"},
+            steps=set(ordered_steps) & {"pre", "index"},
+            _defer_index_registration=defer_index_registration,
             batch_size=batch_size,
             ids=ids,
             mode=mode,
@@ -583,7 +593,7 @@ class ColdHotIndexer:
 
         hot_task = self.hot.index(
             job_manager,
-            steps=set(Step.order(steps)) & {"index", "post"},
+            steps=set(ordered_steps) & {"index", "post"},
             batch_size=batch_size,
             ids=ids,
             mode="merge",

--- a/biothings/hub/dataindex/indexer_registrar.py
+++ b/biothings/hub/dataindex/indexer_registrar.py
@@ -79,6 +79,14 @@ class IndexJobStateRegistrar:
 
         self._done(func)
 
+    def succeed_without_registration(self):
+        def func(job, delta_build):
+            job["status"] = "success"
+            # Do not leave a stale ready record visible while a later step is still required.
+            delta_build["index"] = {self.index_name: {"__REMOVE__": True}}
+
+        self._done(func)
+
     def _done(self, func):
         self.stage.at(Stage.STARTED)
         self.stage = Stage.DONE

--- a/biothings/hub/datatransform/datatransform.py
+++ b/biothings/hub/datatransform/datatransform.py
@@ -400,6 +400,11 @@ class DataTransform:
         keys = field.split(".")
         try:
             for k in keys:
+                if isinstance(value, (list, tuple)):
+                    # assuming we have a list of dict with k as one of the keys
+                    value = [e[k] for e in value if isinstance(e, dict) and e.get(k) is not None]
+                    # can't descend any further into a list, return the collected values
+                    return [str(v) for v in value]
                 value = value[k]
         except KeyError:
             return None

--- a/biothings/hub/datatransform/datatransform_api.py
+++ b/biothings/hub/datatransform/datatransform_api.py
@@ -162,11 +162,14 @@ class DataTransformAPI(DataTransform):
             query = q_out["query"]
             val = self._parse_h(q_out)
             if val:
+                # _nested_lookup may return a single value or a list of values
+                # (e.g. a one-to-many field such as ensembl.gene)
+                vals = val if isinstance(val, list) else [val]
                 if query not in qm_struct.keys():
-                    qm_struct[query] = [val]
+                    qm_struct[query] = vals
                 else:
                     self.one_to_many_cnt += 1
-                    qm_struct[query] = qm_struct[query] + [val]
+                    qm_struct[query] = qm_struct[query] + vals
         # self.logger.debug("parse_querymany num qm_struct keys: {}"\
         #        .format(len(qm_struct.keys())))
         # self.logger.info("parse_querymany running one_to_many_cnt: {}"\

--- a/biothings/web/analytics/events.py
+++ b/biothings/web/analytics/events.py
@@ -74,6 +74,16 @@ class Event(UserDict):
 
         raise ValueError("CID Version.")
 
+    def _ga4_request_params(self):
+        params = {"page_location": f"{self.host}{self.path}"}
+
+        if isinstance(self.referer, str):
+            # Parameter values (including item parameter values) must be 100 character or fewer.
+            if len(self.referer) <= 100:
+                params["page_referrer"] = self.referer
+
+        return params
+
     def to_GA4_payload(self, measurement_id, cid_version=1):
         # Document about page_view event: https://support.google.com/analytics/answer/9964640#pageviews&zippy=%2Cin-this-article
         # GA4 does not support [Document path as UA](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#dp)
@@ -84,17 +94,11 @@ class Event(UserDict):
             "name": "page_view",
             "params": _clean(
                 {
-                    "page_location": f"{self.host}{self.path}",
+                    **self._ga4_request_params(),
                     "page_title": self.path.strip("/").replace("/", "-"),
                 }
             ),
         }
-
-        # add document referer
-        if isinstance(self.referer, str):
-            # Parameter values (including item parameter values) must be 100 character or fewer.
-            if len(self.referer) <= 100:
-                payload["params"]["page_referrer"] = self.referer
 
         # add user_agent
         if self.user_agent:
@@ -130,6 +134,7 @@ class GAEvent(Event):
                     "name": self["action"],
                     "params": _clean(
                         {
+                            **self._ga4_request_params(),
                             "event_category": self["category"],
                             "event_label": self.get("label", ""),
                             "value": self.get("value", ""),

--- a/biothings/web/analytics/notifiers.py
+++ b/biothings/web/analytics/notifiers.py
@@ -39,7 +39,7 @@ class AnalyticsMixin(RequestHandler):
         request_info["user_agent"] = self.request.headers.get("User-Agent")
         request_info["host"] = self.request.host
         request_info["path"] = self.request.path
-        request_info["referer"] = self.request.headers.get("Client-Type") or self.request.headers.get("Referer")
+        request_info["referer"] = self.request.headers.get("Referer")
         self.event["__request__"] = request_info
 
         if hasattr(self, "biothings"):

--- a/biothings/web/analytics/notifiers.py
+++ b/biothings/web/analytics/notifiers.py
@@ -39,7 +39,7 @@ class AnalyticsMixin(RequestHandler):
         request_info["user_agent"] = self.request.headers.get("User-Agent")
         request_info["host"] = self.request.host
         request_info["path"] = self.request.path
-        request_info["referer"] = self.request.headers.get("Referer")
+        request_info["referer"] = self.request.headers.get("Client-Type") or self.request.headers.get("Referer")
         self.event["__request__"] = request_info
 
         if hasattr(self, "biothings"):

--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -707,8 +707,12 @@ class ESQueryBuilder:
         Override this to customize default match query.
         By default it implements a multi_match query.
         """
-        assert isinstance(q, (str, int, float, bool))
-        assert isinstance(scopes, (list, tuple, str)) and scopes
+        if not isinstance(q, (str, int, float, bool)):
+            raise ValueError("Query parameter 'q' must be a primitive type (string, integer, float, or boolean).")        
+
+        if not isinstance(scopes, (list, tuple, str)) or not scopes:
+            raise ValueError("Parameter 'scopes' must be a non-empty list, tuple, or string.")
+        
         _params = dict(query=q, fields=scopes, operator="AND", lenient=True)
         if options.analyzer:
             _params["analyzer"] = options.analyzer

--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -712,7 +712,7 @@ class ESQueryBuilder:
 
         if not isinstance(scopes, (list, tuple, str)) or not scopes:
             raise ValueError("Parameter 'scopes' must be a non-empty list, tuple, or string.")
-        
+
         _params = dict(query=q, fields=scopes, operator="AND", lenient=True)
         if options.analyzer:
             _params["analyzer"] = options.analyzer

--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -708,7 +708,7 @@ class ESQueryBuilder:
         By default it implements a multi_match query.
         """
         if not isinstance(q, (str, int, float, bool)):
-            raise ValueError("Query parameter 'q' must be a primitive type (string, integer, float, or boolean).")        
+            raise ValueError("Query parameter 'q' must be a primitive type (string, integer, float, or boolean).")
 
         if not isinstance(scopes, (list, tuple, str)) or not scopes:
             raise ValueError("Parameter 'scopes' must be a non-empty list, tuple, or string.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     'tornado==6.5.3; python_version >= "3.9.0"',
     "gitpython>=3.1.0",
     "elasticsearch[async]>=7, <8; python_version < '3.7.0'",
-    "elasticsearch[async]>=8, <9; python_version >= '3.7.0'",
+    "elasticsearch[async]>=8.18,<9; python_version >= '3.7.0'",
     'singledispatchmethod; python_version < "3.8.0"',
     'dataclasses; python_version < "3.7.0"',
     "jmespath>=0.7.1,<2.0.0",  # support jmespath query parameter

--- a/tests/hub/dataindex/test_indexer_lifecycle.py
+++ b/tests/hub/dataindex/test_indexer_lifecycle.py
@@ -1,0 +1,260 @@
+import asyncio
+import copy
+import importlib
+
+import pytest
+
+
+class FakeSrcBuildCollection:
+    def __init__(self, docs):
+        self.docs = {doc["_id"]: copy.deepcopy(doc) for doc in docs}
+
+    def find(self, query=None):
+        return [copy.deepcopy(doc) for doc in self.docs.values() if self._matches(doc, query or {})]
+
+    def find_one(self, query):
+        for doc in self.docs.values():
+            if self._matches(doc, query):
+                return copy.deepcopy(doc)
+        return None
+
+    def replace_one(self, query, doc):
+        existing = self.find_one(query)
+        assert existing, f"document not found: {query}"
+        self.docs[existing["_id"]] = copy.deepcopy(doc)
+
+    def update(self, query, update):
+        doc = self._find_stored(query)
+        assert doc, f"document not found: {query}"
+        for op, changes in update.items():
+            if op == "$push":
+                for path, value in changes.items():
+                    parent, key = self._ensure_parent(doc, path)
+                    parent.setdefault(key, []).append(copy.deepcopy(value))
+            elif op == "$addToSet":
+                for path, value in changes.items():
+                    parent, key = self._ensure_parent(doc, path)
+                    values = parent.setdefault(key, [])
+                    if value not in values:
+                        values.append(copy.deepcopy(value))
+            elif op == "$pull":
+                for path, value in changes.items():
+                    parent, key = self._ensure_parent(doc, path)
+                    parent[key] = [item for item in parent.get(key, []) if item != value]
+            elif op == "$unset":
+                for path in changes:
+                    parent, key = self._ensure_parent(doc, path)
+                    parent.pop(key, None)
+            else:
+                raise NotImplementedError(op)
+
+    def _find_stored(self, query):
+        for doc in self.docs.values():
+            if self._matches(doc, query):
+                return doc
+        return None
+
+    def _matches(self, doc, query):
+        return all(self._get(doc, path) == expected for path, expected in query.items())
+
+    def _get(self, doc, path):
+        value = doc
+        for part in path.split("."):
+            if not isinstance(value, dict) or part not in value:
+                return None
+            value = value[part]
+        return value
+
+    def _ensure_parent(self, doc, path):
+        value = doc
+        parts = path.split(".")
+        for part in parts[:-1]:
+            value = value.setdefault(part, {})
+        return value, parts[-1]
+
+
+def make_build_doc(index=None):
+    doc = {
+        "_id": "test_build",
+        "target_name": "test_build",
+        "build_config": {
+            "name": "test",
+            "doc_type": "doc",
+        },
+        "mapping": {},
+        "_meta": {},
+        "jobs": [],
+    }
+    if index is not None:
+        doc["index"] = index
+    return doc
+
+
+@pytest.fixture
+def dataindex_modules(root_configuration, tmp_path):
+    root_configuration.override(
+        {
+            "__file__": str(tmp_path / "test_config.py"),
+            "HUB_DB_BACKEND": {
+                "module": "biothings.utils.sqlite3",
+                "sqlite_db_folder": str(tmp_path),
+            },
+            "DATA_HUB_DB_DATABASE": "indexer_lifecycle_hubdb",
+        }
+    )
+
+    importlib.import_module("biothings.hub")._config_for_app(root_configuration)
+    indexer_module = importlib.import_module("biothings.hub.dataindex.indexer")
+    snapshooter_module = importlib.import_module("biothings.hub.dataindex.snapshooter")
+
+    yield indexer_module, snapshooter_module
+
+    root_configuration.reset()
+
+
+def make_lifecycle_indexer_class(indexer_module):
+    class LifecycleIndexer(indexer_module.Indexer):
+        async def pre_index(self, *args, mode, **kwargs):
+            return {
+                "__REPLACE__": True,
+                "host": self.es_client_args.get("hosts"),
+                "environment": self.env_name,
+            }
+
+        async def do_index(self, job_manager, batch_size, ids, mode, **kwargs):
+            return {
+                "count": 2,
+                "created_at": "index-step",
+            }
+
+        async def post_index(self, *args, **kwargs):
+            return {
+                "post": {
+                    "embeddings": "done",
+                    "force_merge": "done",
+                }
+            }
+
+    return LifecycleIndexer
+
+
+def make_indexer(collection, indexer_class):
+    build_doc = collection.find_one({"_id": "test_build"})
+    return indexer_class(
+        build_doc,
+        {
+            "name": "local",
+            "args": {
+                "hosts": "http://localhost:9200",
+            },
+        },
+        "test_index",
+    )
+
+
+def test_full_index_flow_registers_ready_index_only_after_post(monkeypatch, dataindex_modules):
+    indexer_module, _ = dataindex_modules
+    lifecycle_indexer = make_lifecycle_indexer_class(indexer_module)
+    collection = FakeSrcBuildCollection([make_build_doc()])
+    monkeypatch.setattr(indexer_module, "get_src_build", lambda: collection)
+    observations = []
+
+    class ObservingIndexer(lifecycle_indexer):
+        async def post_index(self, *args, **kwargs):
+            build_doc = collection.find_one({"_id": self.build_name})
+            observations.append(copy.deepcopy(build_doc.get("index", {})))
+            return await super().post_index(*args, **kwargs)
+
+    indexer = make_indexer(collection, ObservingIndexer)
+
+    asyncio.run(indexer.index(object(), steps=("pre", "index", "post")))
+
+    assert "test_index" not in observations[0]
+    build_doc = collection.find_one({"_id": "test_build"})
+    assert build_doc["index"]["test_index"] == {
+        "host": "http://localhost:9200",
+        "environment": "local",
+        "count": 2,
+        "created_at": "index-step",
+        "post": {
+            "embeddings": "done",
+            "force_merge": "done",
+        },
+    }
+
+
+def test_index_without_post_registers_ready_index_after_index(monkeypatch, dataindex_modules):
+    indexer_module, _ = dataindex_modules
+    lifecycle_indexer = make_lifecycle_indexer_class(indexer_module)
+    collection = FakeSrcBuildCollection([make_build_doc()])
+    monkeypatch.setattr(indexer_module, "get_src_build", lambda: collection)
+
+    indexer = make_indexer(collection, lifecycle_indexer)
+
+    asyncio.run(indexer.index(object(), steps=("pre", "index")))
+
+    build_doc = collection.find_one({"_id": "test_build"})
+    assert build_doc["index"]["test_index"] == {
+        "host": "http://localhost:9200",
+        "environment": "local",
+        "count": 2,
+        "created_at": "index-step",
+    }
+
+
+def test_post_failure_after_index_success_does_not_expose_ready_index(monkeypatch, dataindex_modules):
+    indexer_module, _ = dataindex_modules
+    lifecycle_indexer = make_lifecycle_indexer_class(indexer_module)
+    collection = FakeSrcBuildCollection(
+        [
+            make_build_doc(
+                index={
+                    "test_index": {
+                        "environment": "local",
+                        "count": 99,
+                    }
+                }
+            )
+        ]
+    )
+    monkeypatch.setattr(indexer_module, "get_src_build", lambda: collection)
+
+    class FailingPostIndexer(lifecycle_indexer):
+        async def post_index(self, *args, **kwargs):
+            raise RuntimeError("force merge failed")
+
+    indexer = make_indexer(collection, FailingPostIndexer)
+
+    with pytest.raises(RuntimeError, match="force merge failed"):
+        asyncio.run(indexer.index(object(), steps=("pre", "index", "post")))
+
+    build_doc = collection.find_one({"_id": "test_build"})
+    assert "test_index" not in build_doc.get("index", {})
+    assert build_doc["jobs"][-2]["step"] == "index"
+    assert build_doc["jobs"][-2]["status"] == "success"
+    assert build_doc["jobs"][-1]["step"] == "post-index"
+    assert build_doc["jobs"][-1]["status"] == "failed"
+    assert build_doc["jobs"][-1]["err"] == "force merge failed"
+
+
+def test_snapshot_lookup_cannot_find_index_until_post_succeeds(monkeypatch, dataindex_modules):
+    indexer_module, snapshooter = dataindex_modules
+    lifecycle_indexer = make_lifecycle_indexer_class(indexer_module)
+    collection = FakeSrcBuildCollection([make_build_doc()])
+    monkeypatch.setattr(indexer_module, "get_src_build", lambda: collection)
+    monkeypatch.setattr(snapshooter, "get_src_build", lambda: collection)
+    snapshot_env = object.__new__(snapshooter.SnapshotEnv)
+    snapshot_env.idxenv = "local"
+
+    class SnapshotLookupIndexer(lifecycle_indexer):
+        async def post_index(self, *args, **kwargs):
+            with pytest.raises(ValueError, match="Not a hub-managed index"):
+                snapshooter.SnapshotEnv._doc(snapshot_env, "test_index")
+            return await super().post_index(*args, **kwargs)
+
+    indexer = make_indexer(collection, SnapshotLookupIndexer)
+
+    asyncio.run(indexer.index(object(), steps=("pre", "index", "post")))
+
+    build_doc = snapshooter.SnapshotEnv._doc(snapshot_env, "test_index")
+    assert build_doc["_id"] == "test_build"

--- a/tests/web/analytics/test_channels.py
+++ b/tests/web/analytics/test_channels.py
@@ -1,13 +1,23 @@
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, call, patch
 
 import aiohttp
 import pytest
-from aioresponses import aioresponses
 
 from biothings.utils import serializer
 from biothings.web.analytics.channels import GA4Channel, SlackChannel
 from biothings.web.analytics.events import GAEvent, Message
+
+
+class MockClientResponse:
+    def __init__(self, status):
+        self.status = status
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
 
 
 @pytest.mark.asyncio
@@ -18,18 +28,19 @@ async def test_send_Slack():
 
     assert await channel.handles(message)
 
-    with patch("aiohttp.ClientSession.post") as mock_post, patch("certifi.where") as mock_certifi, patch(
-        "ssl.create_default_context"
+    with patch(
+        "biothings.web.analytics.channels.aiohttp.ClientSession.post", return_value=MockClientResponse(200)
+    ) as mock_post, patch("biothings.web.analytics.channels.certifi.where") as mock_certifi, patch(
+        "biothings.web.analytics.channels.ssl.create_default_context"
     ) as mock_ssl_context:
 
         # Mocking the post request response and certifi.where
-        mock_post.return_value.__aenter__.return_value.status = 200
         mock_certifi.return_value = "/path/to/fake_cert.pem"  # Any dummy path
         mock_ssl_context.return_value = None  # Return None to bypass actual SSL context
 
-        with aioresponses() as responses:
-            responses.post(url, status=200)
-            await channel.send(message)
+        await channel.send(message)
+
+    mock_post.assert_called_once_with(url, json=message.to_slack_payload(), ssl=None)
 
 
 @pytest.mark.asyncio
@@ -52,12 +63,22 @@ async def test_send_GA4():
     channel = GA4Channel("GA4_MEASUREMENT_ID", "GA4_API_SECRET", 1)
     assert await channel.handles(event)
 
-    with aioresponses() as responses:
-        # Mock the URL to return a 200 OK response
-        responses.post(channel.url, status=200)
+    expected_events = event.to_GA4_payload(channel.measurement_id, channel.uid_version)
+    expected_data = serializer.to_json(
+        {
+            "client_id": "12345",
+            "user_id": "67890",
+            "events": expected_events,
+        },
+        return_bytes=True,
+    )
 
-        # If the function completes without raising an exception, the test will pass
+    with patch(
+        "biothings.web.analytics.channels.aiohttp.ClientSession.post", return_value=MockClientResponse(200)
+    ) as mock_post, patch.object(event, "_cid", side_effect=[12345, 67890]):
         await channel.send(event)
+
+    mock_post.assert_called_once_with(channel.url, data=expected_data)
 
 
 @pytest.mark.asyncio
@@ -68,15 +89,15 @@ async def test_send_GA4_request_retries():
     data = serializer.to_json({"test": "data"}, return_bytes=True)
 
     async with aiohttp.ClientSession() as session:
-        with aioresponses() as responses:
-            # Mock the URL to return HTTP 500 on the first call and HTTP 200 on the second call
-            responses.post(url, status=500)
-            responses.post(url, status=200)
-
+        with patch(
+            "biothings.web.analytics.channels.aiohttp.ClientSession.post",
+            side_effect=[MockClientResponse(500), MockClientResponse(200)],
+        ) as mock_post, patch("biothings.web.analytics.channels.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
             await channel.send_request(session, url, data)
 
-            assert responses._responses[0].status == 500
-            assert responses._responses[1].status == 200
+    assert mock_post.call_count == channel.max_retries + 1
+    mock_post.assert_has_calls([call(url, data=data), call(url, data=data)])
+    mock_sleep.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -86,13 +107,12 @@ async def test_send_GA4_request_max_retries():
     data = serializer.to_json({"test": "data"}, return_bytes=True)
 
     async with aiohttp.ClientSession() as session:
-        with aioresponses() as responses:
-            # Mock the URL to always return a 500 response
-            responses.post(url, status=500)
-            responses.post(url, status=500)
-
+        with patch(
+            "biothings.web.analytics.channels.aiohttp.ClientSession.post",
+            side_effect=[MockClientResponse(500) for _ in range(channel.max_retries + 1)],
+        ) as mock_post, patch("biothings.web.analytics.channels.asyncio.sleep", new_callable=AsyncMock):
             with pytest.raises(Exception, match="GA4Channel: Maximum retries reached. Unable to complete request."):
                 await channel.send_request(session, url, data)
 
-            # Ensure the post method was called max_retries + 1 times
-            assert len(responses._responses) == channel.max_retries + 1
+    assert mock_post.call_count == channel.max_retries + 1
+    mock_post.assert_has_calls([call(url, data=data) for _ in range(channel.max_retries + 1)])

--- a/tests/web/analytics/test_events.py
+++ b/tests/web/analytics/test_events.py
@@ -69,3 +69,38 @@ def test_event_ga4_2():
     )
     print(event.to_GA4_payload("GA4_MEASUREMENT_ID"))
     print(event.to_GA4_payload("GA4_MEASUREMENT_ID", 2))
+
+
+def test_event_ga4_request_context_on_custom_events():
+    event = GAEvent(
+        {
+            "__request__": {
+                "user_agent": "Mozilla/5.0",
+                "referer": "https://data-staging.niaid.nih.gov/",
+                "user_ip": "127.0.0.1",
+                "host": "api-staging.data.niaid.nih.gov",
+                "path": "/v1/query",
+            },
+            "__secondary__": [
+                GAEvent(
+                    {
+                        "category": "parameter_tracking",
+                        "action": "field_filter",
+                        "label": "all",
+                    }
+                )
+            ],
+            "category": "v1_api",
+            "action": "query_get",
+        }
+    )
+
+    page_view, query_get, field_filter = event.to_GA4_payload("GA4_MEASUREMENT_ID")
+
+    assert page_view["params"]["page_referrer"] == "https://data-staging.niaid.nih.gov/"
+    assert query_get["name"] == "query_get"
+    assert query_get["params"]["page_referrer"] == "https://data-staging.niaid.nih.gov/"
+    assert query_get["params"]["page_location"] == "api-staging.data.niaid.nih.gov/v1/query"
+    assert field_filter["name"] == "field_filter"
+    assert field_filter["params"]["page_referrer"] == "https://data-staging.niaid.nih.gov/"
+    assert field_filter["params"]["page_location"] == "api-staging.data.niaid.nih.gov/v1/query"

--- a/tests/web/analytics/test_notifiers.py
+++ b/tests/web/analytics/test_notifiers.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tornado.httputil import HTTPHeaders
+
+from biothings.web.analytics.events import Event
+from biothings.web.analytics.notifiers import AnalyticsMixin
+
+
+class DummyNotifier:
+    async def broadcast(self, event):
+        pass
+
+
+class DummyAnalyticsHandler(AnalyticsMixin):
+    def __init__(self, headers):
+        self.request = SimpleNamespace(
+            headers=HTTPHeaders(headers),
+            remote_ip="127.0.0.1",
+            host="example.org",
+            path="/v1/query",
+        )
+        self.event = Event()
+        self._biothings = SimpleNamespace(notifier=DummyNotifier())
+
+    @property
+    def settings(self):
+        return {}
+
+    @property
+    def biothings(self):
+        return self._biothings
+
+    def get_argument(self, name, default=None):
+        return default
+
+
+def test_analytics_mixin_records_client_type_as_referer():
+    handler = DummyAnalyticsHandler(
+        {
+            "Referer": "https://data.niaid.nih.gov/",
+            "Client-Type": "ui",
+        }
+    )
+
+    with patch("biothings.web.analytics.notifiers.asyncio.get_event_loop", return_value=object()), patch(
+        "biothings.web.analytics.notifiers.asyncio.run_coroutine_threadsafe"
+    ) as schedule:
+        handler.on_finish()
+
+    schedule.call_args.args[0].close()
+    assert handler.event["__request__"]["referer"] == "ui"
+    assert handler.event.to_GA4_payload("GA4_MEASUREMENT_ID")[0]["params"]["page_referrer"] == "ui"
+
+
+def test_analytics_mixin_referer_falls_back_to_referer_header():
+    handler = DummyAnalyticsHandler({"Referer": "https://data.niaid.nih.gov/"})
+
+    with patch("biothings.web.analytics.notifiers.asyncio.get_event_loop", return_value=object()), patch(
+        "biothings.web.analytics.notifiers.asyncio.run_coroutine_threadsafe"
+    ) as schedule:
+        handler.on_finish()
+
+    schedule.call_args.args[0].close()
+    assert handler.event["__request__"]["referer"] == "https://data.niaid.nih.gov/"

--- a/tests/web/analytics/test_notifiers.py
+++ b/tests/web/analytics/test_notifiers.py
@@ -35,11 +35,10 @@ class DummyAnalyticsHandler(AnalyticsMixin):
         return default
 
 
-def test_analytics_mixin_records_client_type_as_referer():
+def test_analytics_mixin_records_referer_header():
     handler = DummyAnalyticsHandler(
         {
             "Referer": "https://data.niaid.nih.gov/",
-            "Client-Type": "ui",
         }
     )
 
@@ -49,8 +48,11 @@ def test_analytics_mixin_records_client_type_as_referer():
         handler.on_finish()
 
     schedule.call_args.args[0].close()
-    assert handler.event["__request__"]["referer"] == "ui"
-    assert handler.event.to_GA4_payload("GA4_MEASUREMENT_ID")[0]["params"]["page_referrer"] == "ui"
+    assert handler.event["__request__"]["referer"] == "https://data.niaid.nih.gov/"
+    assert (
+        handler.event.to_GA4_payload("GA4_MEASUREMENT_ID")[0]["params"]["page_referrer"]
+        == "https://data.niaid.nih.gov/"
+    )
 
 
 def test_analytics_mixin_referer_falls_back_to_referer_header():


### PR DESCRIPTION
## v1.1.1 (2026/06/18)

### biothings.hub improvements

* Fixed index lifecycle registration so indexes are only marked ready after post-index steps complete. ([[#449](https://github.com/biothings/biothings.api/pull/449)](https://github.com/biothings/biothings.api/pull/449))
* Fixed DataTransform nested lookup handling for lists of dictionaries and one-to-many API lookup results.

### biothings.web improvements

* Fixed GA4 analytics request context handling so referer and page location are propagated to custom events. ([[#450](https://github.com/biothings/biothings.api/pull/450)](https://github.com/biothings/biothings.api/pull/450))
* Replaced risky Elasticsearch query assertions with explicit user-input validation. ([[#447](https://github.com/biothings/biothings.api/pull/447)](https://github.com/biothings/biothings.api/pull/447))

### Misc improvements

* Fixed GA4 analytics channel tests for newer aiohttp behavior without relying on aioresponses internals. ([[#448](https://github.com/biothings/biothings.api/pull/448)](https://github.com/biothings/biothings.api/pull/448))
* Updated the Elasticsearch dependency floor to 8.18+ for supported Python versions.