### PR TITLE
Fix option min validation and formatter include

### DIFF
--- a/biothings/web/options/manager.py
+++ b/biothings/web/options/manager.py
@@ -545,7 +545,7 @@ class Validator:
             raise OptionError(keyword=self.keyword, max=self.max, num=num)
 
     def _check_list_min(self, container):
-        if len(container) > self.min:
+        if len(container) < self.min:
             raise OptionError(keyword=self.keyword, min=self.min, size=len(container))
 
     def _check_num_min(self, num):

--- a/biothings/web/query/formatter.py
+++ b/biothings/web/query/formatter.py
@@ -30,7 +30,7 @@ class FormatterDict(UserDict):
 
     def include(self, keys):
         for key in list(self.keys()):
-            if key in keys:
+            if key not in keys:
                 self.pop(key)
 
     def wrap(self, key, kls):

--- a/tests/web/options/test_options.py
+++ b/tests/web/options/test_options.py
@@ -114,3 +114,24 @@ def test_03():
 
     opt = Option({"keyword": "size", "type": int})
     assert opt.parse(reqargs) == 10
+
+
+def test_list_min_rejects_too_few_values():
+    reqargs = ReqArgs(query={"ids": "cdk"})
+
+    opt = Option({"keyword": "ids", "type": list, "min": 2})
+
+    with pytest.raises(OptionError) as err:
+        opt.parse(reqargs)
+
+    assert err.value.info["keyword"] == "ids"
+    assert err.value.info["min"] == 2
+    assert err.value.info["size"] == 1
+
+
+def test_list_min_allows_enough_values():
+    reqargs = ReqArgs(query={"ids": "cdk,cdk2"})
+
+    opt = Option({"keyword": "ids", "type": list, "min": 2})
+
+    assert opt.parse(reqargs) == ["cdk", "cdk2"]

--- a/tests/web/query/test_formatter.py
+++ b/tests/web/query/test_formatter.py
@@ -1,4 +1,5 @@
 from biothings.web.query import ESResultFormatter
+from biothings.web.query.formatter import FormatterDict
 
 
 def test_es_1():
@@ -54,3 +55,17 @@ def test_es_3():
             one=True,
         )
     )
+
+
+def test_formatter_dict_include_keeps_only_requested_keys():
+    data = FormatterDict(
+        {
+            "_id": "1017",
+            "symbol": "CDK2",
+            "name": "cyclin dependent kinase 2",
+        }
+    )
+
+    data.include({"_id", "symbol"})
+
+    assert data == {"_id": "1017", "symbol": "CDK2"}


### PR DESCRIPTION
## Summary

- Fix list minimum-length validation so lists shorter than the configured minimum are rejected.
- Fix FormatterDict.include() so it keeps requested keys instead of removing them.
- Add regression tests for both behaviors.

## Testing

- python -m pytest tests/web/options/test_options.py tests/web/query/test_formatter.py