### PR TITLE
Add source mapping configuration to sources page

### DIFF
--- a/biothings/hub/databuild/backend.py
+++ b/biothings/hub/databuild/backend.py
@@ -7,9 +7,9 @@ import os
 from functools import partial
 
 import biothings.utils.mongo as mongo
-from biothings import config as btconfig
 from biothings.utils.backend import DocBackendBase, DocESBackend, DocMongoBackend
 from biothings.utils.common import get_random_string, get_timestamp
+from biothings.utils.dataload import merge_struct
 from biothings.utils.es import ESIndexer
 from biothings.utils.hub_db import get_source_fullname, get_src_build
 
@@ -167,19 +167,19 @@ class SourceDocMongoBackend(SourceDocBackendBase):
             if src and src.get("upload"):
                 latest_upload_date = None
                 meta = {}
+                # collect each sub-source's field mapping (from src_master) so they can be
+                # merged into a single mapping stored at the main-source level below
+                sub_mappings = []
                 for job_name in src["upload"].get("jobs", {}):
                     job = src["upload"]["jobs"][job_name]
                     # "step" is the actual sub-source name
                     sub_source = job.get("step")
                     docm = self.master.find_one({"_id": sub_source})
-                    # store the src_meta for each sub-source, if any. This is useful for instance to store mapping information.
+                    # store the src_meta for each sub-source, if any.
                     if docm and docm.get("src_meta"):
-                        src_meta_doc = docm["src_meta"]
-                        # optionally expose each source's field mapping in the build metadata,
-                        # enabled via the INCLUDE_SOURCE_MAPPING_IN_METADATA config flag.
-                        if getattr(btconfig, "INCLUDE_SOURCE_MAPPING_IN_METADATA", False) and docm.get("mapping"):
-                            src_meta_doc.setdefault("code", {})["mapping"] = docm["mapping"]
-                        meta[sub_source] = src_meta_doc
+                        meta[sub_source] = docm["src_meta"]
+                    if docm and docm.get("mapping"):
+                        sub_mappings.append(docm["mapping"])
                     # Store the latest success upload time
                     if not latest_upload_date or latest_upload_date < job["started_at"]:
                         step_meta = meta.setdefault(sub_source, {})
@@ -229,6 +229,15 @@ class SourceDocMongoBackend(SourceDocBackendBase):
                     subname, metad = meta.popitem()
                     for k, v in metad.items():
                         src_meta.setdefault(src["_id"], {}).setdefault(k, v)
+
+                # merge all sub-source field mappings into a single mapping stored at the
+                # main-source level (_meta.src.<source>.mapping). For multi-uploader sources
+                # the individual uploader mappings are merged together into one.
+                if sub_mappings:
+                    merged_mapping = sub_mappings[0]
+                    for mapping in sub_mappings[1:]:
+                        merged_mapping = merge_struct(merged_mapping, mapping)
+                    src_meta.setdefault(src["_id"], {})["mapping"] = merged_mapping
             if subsrc_versions:
                 version = subsrc_versions[0]["version"]
                 src_version[src["_id"]] = version

--- a/biothings/hub/databuild/backend.py
+++ b/biothings/hub/databuild/backend.py
@@ -7,6 +7,7 @@ import os
 from functools import partial
 
 import biothings.utils.mongo as mongo
+from biothings import config as btconfig
 from biothings.utils.backend import DocBackendBase, DocESBackend, DocMongoBackend
 from biothings.utils.common import get_random_string, get_timestamp
 from biothings.utils.es import ESIndexer
@@ -174,7 +175,9 @@ class SourceDocMongoBackend(SourceDocBackendBase):
                     # store the src_meta for each sub-source, if any. This is useful for instance to store mapping information.
                     if docm and docm.get("src_meta"):
                         src_meta_doc = docm["src_meta"]
-                        if docm.get("mapping"):
+                        # optionally expose each source's field mapping in the build metadata,
+                        # enabled via the INCLUDE_SOURCE_MAPPING_IN_METADATA config flag.
+                        if getattr(btconfig, "INCLUDE_SOURCE_MAPPING_IN_METADATA", False) and docm.get("mapping"):
                             src_meta_doc.setdefault("code", {})["mapping"] = docm["mapping"]
                         meta[sub_source] = src_meta_doc
                     # Store the latest success upload time

--- a/biothings/hub/databuild/backend.py
+++ b/biothings/hub/databuild/backend.py
@@ -171,8 +171,12 @@ class SourceDocMongoBackend(SourceDocBackendBase):
                     # "step" is the actual sub-source name
                     sub_source = job.get("step")
                     docm = self.master.find_one({"_id": sub_source})
+                    # store the src_meta for each sub-source, if any. This is useful for instance to store mapping information.
                     if docm and docm.get("src_meta"):
-                        meta[sub_source] = docm["src_meta"]
+                        src_meta_doc = docm["src_meta"]
+                        if docm.get("mapping"):
+                            src_meta_doc.setdefault("code", {})["mapping"] = docm["mapping"]
+                        meta[sub_source] = src_meta_doc
                     # Store the latest success upload time
                     if not latest_upload_date or latest_upload_date < job["started_at"]:
                         step_meta = meta.setdefault(sub_source, {})

--- a/biothings/hub/default_config.py
+++ b/biothings/hub/default_config.py
@@ -132,11 +132,6 @@ SKIP_DUMPER_SCHEDULE = False
 # Skip all scheduled uploader jobs after a success dump
 SKIP_UPLOADER_POLL = False
 
-# When True, each source's field mapping (from src_master) is included in a build's
-# metadata, under _meta.src.<source>.code.mapping (per sub-source for multi-uploader
-# sources). Defaults to False so the mapping is only exposed when explicitly enabled.
-INCLUDE_SOURCE_MAPPING_IN_METADATA = False
-
 # Auto archive feature will use this configuration to get schedule config for corresponding build configuration.
 # If not set it will use the default value defined in AutoArchiveManager
 AUTO_ARCHIVE_CONFIG = None

--- a/biothings/hub/default_config.py
+++ b/biothings/hub/default_config.py
@@ -132,6 +132,11 @@ SKIP_DUMPER_SCHEDULE = False
 # Skip all scheduled uploader jobs after a success dump
 SKIP_UPLOADER_POLL = False
 
+# When True, each source's field mapping (from src_master) is included in a build's
+# metadata, under _meta.src.<source>.code.mapping (per sub-source for multi-uploader
+# sources). Defaults to False so the mapping is only exposed when explicitly enabled.
+INCLUDE_SOURCE_MAPPING_IN_METADATA = False
+
 # Auto archive feature will use this configuration to get schedule config for corresponding build configuration.
 # If not set it will use the default value defined in AutoArchiveManager
 AUTO_ARCHIVE_CONFIG = None

--- a/biothings/web/handlers/query.py
+++ b/biothings/web/handlers/query.py
@@ -183,16 +183,17 @@ class MetadataSourceHandler(BaseQueryHandler):
         including multi-uploader sources). ``func`` receives the source dict that holds the
         ``"mapping"`` key and replaces or drops that key in place.
 
-        Each source dict is copied because ``src`` is part of the metadata cache shared
-        across requests, and mutating it would remove the mapping for later requests. Only
-        the source dicts themselves are copied (not their nested mappings), since ``func``
-        must not modify the mapping content itself.
+        ``src`` belongs to the metadata service's cache, so each source ``func`` touches is
+        copied instead of being edited in place. Handlers currently refresh the metadata on
+        every request, which rebuilds that cache, but copying avoids depending on it. Only
+        the source dicts are copied, not their nested mappings, so ``func`` must not modify
+        the mapping content itself.
         """
         src = dict(src)
         for name, source in src.items():
             if isinstance(source, dict) and "mapping" in source:
-                source = src[name] = dict(source)  # copy before mutating the cached dict
-                func(source)
+                src[name] = dict(source)  # shallow copy so func doesn't edit the cached source
+                func(src[name])
         return src
 
     @staticmethod

--- a/biothings/web/handlers/query.py
+++ b/biothings/web/handlers/query.py
@@ -181,7 +181,7 @@ class MetadataSourceHandler(BaseQueryHandler):
 
         The mapping lives under ``<source>.mapping`` (a single merged mapping per source,
         including multi-uploader sources). ``func`` receives the source dict that holds the
-        ``"mapping"`` key and replaces or drops that key in place.
+        ``"mapping"`` key.
 
         ``src`` belongs to the metadata service's cache, so each source ``func`` touches is
         copied instead of being edited in place. Handlers currently refresh the metadata on
@@ -189,7 +189,7 @@ class MetadataSourceHandler(BaseQueryHandler):
         the source dicts are copied, not their nested mappings, so ``func`` must not modify
         the mapping content itself.
         """
-        src = dict(src)
+        src = dict(src) # shallow copy so func doesn't edit the cached src dict
         for name, source in src.items():
             if isinstance(source, dict) and "mapping" in source:
                 src[name] = dict(source)  # shallow copy so func doesn't edit the cached source

--- a/biothings/web/handlers/query.py
+++ b/biothings/web/handlers/query.py
@@ -29,6 +29,7 @@ biothings.web.handlers.ESRequestHandler
 
 """
 
+import copy
 import logging
 from collections import Counter
 from inspect import iscoroutinefunction
@@ -147,6 +148,14 @@ class MetadataSourceHandler(BaseQueryHandler):
 
         elif self.args.dev:
             meta["software"] = self.biothings.devinfo.get()
+            # flatten each source's field mapping to dotted property keys, matching the
+            # representation used by /metadata/fields
+            if "src" in meta:
+                formatter = self.pipeline.formatter
+                meta["src"] = self._transform_source_mappings(
+                    meta["src"],
+                    lambda source: source.__setitem__("mapping", formatter.transform_mapping(source["mapping"])),
+                )
 
         else:  # remove debug info
             filtered_meta = {}
@@ -154,6 +163,12 @@ class MetadataSourceHandler(BaseQueryHandler):
                 if not key.startswith("_"):
                     filtered_meta[key] = value
             meta = filtered_meta
+            # per-source field mappings (src.<source>.mapping) are only exposed in
+            # dev mode (/metadata?dev); strip them from the public response
+            if "src" in meta:
+                meta["src"] = self._transform_source_mappings(
+                    meta["src"], lambda source: source.pop("mapping", None)
+                )
 
         if iscoroutinefunction(self.extras):
             meta = await self.extras(meta)
@@ -161,6 +176,23 @@ class MetadataSourceHandler(BaseQueryHandler):
             meta = self.extras(meta)
 
         self.finish(dict(sorted(meta.items())))
+
+    @staticmethod
+    def _transform_source_mappings(src, func):
+        """
+        Return a deep copy of the ``src`` metadata after applying ``func`` to every
+        source that carries a field mapping.
+
+        The mapping lives under ``<source>.mapping`` (a single merged mapping per source,
+        including multi-uploader sources). ``func`` receives the source dict that holds the
+        ``"mapping"`` key and mutates it in place (e.g. to drop or flatten the mapping). A
+        deep copy is used so the cached metadata (shared across requests) is left untouched.
+        """
+        src = copy.deepcopy(src)
+        for source in src.values():
+            if isinstance(source, dict) and "mapping" in source:
+                func(source)
+        return src
 
     def extras(self, _meta):
         """
@@ -191,7 +223,44 @@ class MetadataFieldHandler(BaseQueryHandler):
 
         result = self.pipeline.formatter.transform_mapping(mapping, self.args.prefix, self.args.search)
 
+        # annotate each field with the main source(s) that populate it
+        self._annotate_field_sources(result)
+
         self.finish(result)
+
+    def _annotate_field_sources(self, result):
+        """
+        Add a ``source`` key to each field in ``result`` listing the main sources whose
+        field mapping (stored in ``_meta.src.<source>.mapping``) includes that field.
+
+        Sources are identified by flattening each per-source mapping the same way the field
+        list itself is built, so the field paths line up. If no per-source mapping data is
+        available (e.g. an index built before mappings were recorded), no annotation is added.
+        """
+        metadata = self.metadata.get_metadata(self.biothing_type)
+        sources = metadata.get("src", {}) if metadata else {}
+        formatter = self.pipeline.formatter
+
+        # map each field path to the set of main sources that define it
+        field_sources = {}
+        for source, info in sources.items():
+            source_mapping = info.get("mapping") if isinstance(info, dict) else None
+            if not source_mapping:
+                continue
+            for field in formatter.transform_mapping(source_mapping):
+                field_sources.setdefault(field, set()).add(source)
+
+        if not field_sources:
+            return
+
+        for field, definition in result.items():
+            field_srcs = field_sources.get(field)
+            # only annotate fields that actually map to a source; computed fields
+            # (e.g. _id) with no source mapping are left without a "source" key
+            if field_srcs and isinstance(definition, dict):
+                srcs = sorted(field_srcs)
+                definition["source"] = srcs[0] if len(srcs) == 1 else srcs
+
 
 
 async def ensure_awaitable(obj):

--- a/biothings/web/handlers/query.py
+++ b/biothings/web/handlers/query.py
@@ -29,7 +29,6 @@ biothings.web.handlers.ESRequestHandler
 
 """
 
-import copy
 import logging
 from collections import Counter
 from inspect import iscoroutinefunction
@@ -148,14 +147,11 @@ class MetadataSourceHandler(BaseQueryHandler):
 
         elif self.args.dev:
             meta["software"] = self.biothings.devinfo.get()
-            # flatten each source's field mapping to dotted property keys, matching the
-            # representation used by /metadata/fields
+            # replace each source's field mapping with a "fields" list holding only the
+            # dotted field names, using the same flattening as /metadata/fields
             if "src" in meta:
                 formatter = self.pipeline.formatter
-                meta["src"] = self._transform_source_mappings(
-                    meta["src"],
-                    lambda source: source.__setitem__("mapping", formatter.transform_mapping(source["mapping"])),
-                )
+                meta["src"] = self._transform_source_mappings(meta["src"], self._set_source_fields(formatter))
 
         else:  # remove debug info
             filtered_meta = {}
@@ -180,19 +176,36 @@ class MetadataSourceHandler(BaseQueryHandler):
     @staticmethod
     def _transform_source_mappings(src, func):
         """
-        Return a deep copy of the ``src`` metadata after applying ``func`` to every
-        source that carries a field mapping.
+        Return a copy of the ``src`` metadata after applying ``func`` to every source that
+        carries a field mapping.
 
         The mapping lives under ``<source>.mapping`` (a single merged mapping per source,
         including multi-uploader sources). ``func`` receives the source dict that holds the
-        ``"mapping"`` key and mutates it in place (e.g. to drop or flatten the mapping). A
-        deep copy is used so the cached metadata (shared across requests) is left untouched.
+        ``"mapping"`` key and replaces or drops that key in place.
+
+        Each source dict is copied because ``src`` is part of the metadata cache shared
+        across requests, and mutating it would remove the mapping for later requests. Only
+        the source dicts themselves are copied (not their nested mappings), since ``func``
+        must not modify the mapping content itself.
         """
-        src = copy.deepcopy(src)
-        for source in src.values():
+        src = dict(src)
+        for name, source in src.items():
             if isinstance(source, dict) and "mapping" in source:
+                source = src[name] = dict(source)  # copy before mutating the cached dict
                 func(source)
         return src
+
+    @staticmethod
+    def _set_source_fields(formatter):
+        """
+        Build a function replacing a source's ``mapping`` with a ``fields`` list of the
+        dotted field names it provides, e.g.
+        """
+
+        def _set_fields(source):
+            source["fields"] = sorted(formatter.transform_mapping(source.pop("mapping")))
+
+        return _set_fields
 
     def extras(self, _meta):
         """


### PR DESCRIPTION
This pull request introduces improvements to how per-source field mappings are managed and exposed in metadata, and enhances the `/metadata/fields` endpoint to annotate fields with their originating sources. The changes ensure that merged field mappings for multi-uploader sources are stored and managed efficiently, and that sensitive mapping details are only exposed in development mode.

**Metadata handling and field mapping improvements:**

* In `get_src_metadata`, all sub-source field mappings are merged into a single mapping and stored at the main source level (`src.<source>.mapping`). This ensures that multi-uploader sources have a unified field mapping. [[1]](diffhunk://#diff-3d8fd67f92662a7ecb09a99102096da20d02b42f2e7649b96b292b415c5eab49R170-R182) [[2]](diffhunk://#diff-3d8fd67f92662a7ecb09a99102096da20d02b42f2e7649b96b292b415c5eab49R232-R240)
* The `merge_struct` utility is now imported to support merging of field mappings.

**API response and security enhancements:**

* In the `/metadata` endpoint, per-source field mappings are only exposed in development mode. In production, these mappings are stripped from the public response to avoid leaking internal structure.
* When in development mode, each source's mapping is replaced with a `fields` list containing the flattened field names, consistent with `/metadata/fields`. [[1]](diffhunk://#diff-bed92db956ab611579cb6669e13e13461dbaa3ecab6a9b478bd3ce3c4e6c9ec2R150-R167) [[2]](diffhunk://#diff-bed92db956ab611579cb6669e13e13461dbaa3ecab6a9b478bd3ce3c4e6c9ec2R176-R209)
* Utility methods `_transform_source_mappings` and `_set_source_fields` are added to safely apply these transformations without mutating cached metadata.

**Field annotation feature:**

* The `/metadata/fields` endpoint now annotates each field with the main source(s) that define it, using the merged mappings. This helps users trace fields back to their data sources.