### PR TITLE
Fix v1.1.2 Codacy formatting

### DIFF
--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -736,7 +736,7 @@ class ESQueryBuilder:
             if not name:
                 raise ValueError(
                     f"Invalid sort field '{field}': missing field name. "
-                    'Use a comma-separated list of fields, each optionally '
+                    "Use a comma-separated list of fields, each optionally "
                     'prefixed with "-" for descending order, e.g. sort=-taxid,symbol.'
                 )
             if ":" in name:

--- a/tests/web/test_es_exceptions.py
+++ b/tests/web/test_es_exceptions.py
@@ -217,7 +217,9 @@ async def test_es_rejected_execution_exception():
     async def func():
         exc = TransportError("test_es_rejected_execution_exception")
         exc.status_code = 503
-        exc.info = {"error": {"type": "es_rejected_execution_exception", "reason": "rejected execution of TimedRunnable..."}}
+        exc.info = {
+            "error": {"type": "es_rejected_execution_exception", "reason": "rejected execution of TimedRunnable..."}
+        }
         raise exc
 
     with pytest.raises(QueryPipelineException) as exc_info:


### PR DESCRIPTION
Fixes the Codacy formatting issue surfaced on the v1.1.2 release PR before the release is tagged.

Validation:
- `python -m black --check biothings/web/query/builder.py tests/web/test_es_exceptions.py`
- `python -m pytest tests/web/query/test_builder.py tests/web/test_es_exceptions.py`
