### PR TITLE
Restore Python 3.10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - 1.1.x
+      - 1.2.x
 
 jobs:
   install_and_run_tests:
@@ -13,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14', '3.14t']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     services:
       # mongo:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.11', '3.12', '3.13', '3.14', '3.14t' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t' ]
     steps:
       - name: Checkout source
         uses: actions/checkout@v5

--- a/biothings/hub/databuild/builder.py
+++ b/biothings/hub/databuild/builder.py
@@ -32,6 +32,7 @@ from biothings.hub.databuild.mapper import TransparentMapper
 from biothings.hub.dataload.uploader import ResourceNotReady
 from biothings.hub.manager import BaseManager
 from biothings.utils import mongo
+from biothings.utils.asyncio_compat import ExceptionGroup, TaskGroup
 from biothings.utils.backend import DocMongoBackend
 from biothings.utils.common import (
     dotdict,
@@ -887,7 +888,7 @@ class DataBuilder:
         try:
             # TaskGroup raises errors as soon as we know, cancelling the
             # submission loop and pending batches
-            async with asyncio.TaskGroup() as tg:
+            async with TaskGroup() as tg:
                 for big_doc_ids in id_provider:
                     for doc_ids in iter_n(big_doc_ids, batch_size):
                         # try to put some async here to give control back
@@ -925,7 +926,7 @@ class DataBuilder:
                         njobs += 1
                         bnum += 1
                 self.logger.info("%d jobs created for merging step", njobs)
-        except* Exception as eg:
+        except ExceptionGroup as eg:
             raise first_exception(eg) from eg
         return {"%s" % src_name: cnt}
 

--- a/biothings/hub/databuild/differ.py
+++ b/biothings/hub/databuild/differ.py
@@ -13,6 +13,7 @@ from biothings.hub import DIFFER_CATEGORY, DIFFMANAGER_CATEGORY
 from biothings.hub.databuild.backend import generate_folder
 from biothings.hub.datarelease import set_pending_to_release_note
 from biothings.hub.manager import BaseManager
+from biothings.utils.asyncio_compat import ExceptionGroup, TaskGroup
 from biothings.utils.backend import DocMongoBackend
 from biothings.utils.common import dump, first_exception, get_timestamp, loadobj, md5sum, rmdashfr, timesofar
 from biothings.utils.diff import diff_docs_jsonpatch
@@ -342,7 +343,7 @@ class BaseDiffer(object):
                 self.register_status("success", job={"step": "diff-content"})
 
             try:
-                async with asyncio.TaskGroup() as tg:
+                async with TaskGroup() as tg:
                     for id_list_new in data_new:
                         cnt += 1
                         pinfo["description"] = "batch #%s" % cnt
@@ -362,7 +363,7 @@ class BaseDiffer(object):
                             ),
                         )
                         tg.create_task(diffed_new_vs_old(job))
-            except* Exception as eg:
+            except ExceptionGroup as eg:
                 raise first_exception(eg) from eg
             self.logger.info(
                 "Finished calculating diff for the new collection. Total number of docs updated: %s, added: %s",
@@ -383,7 +384,7 @@ class BaseDiffer(object):
                 self.logger.info("(Deleted: {})".format(res["delete"]))
 
             try:
-                async with asyncio.TaskGroup() as tg:
+                async with TaskGroup() as tg:
                     for id_list_old in data_old:
                         cnt += 1
                         pinfo["description"] = "batch #%s" % cnt
@@ -393,7 +394,7 @@ class BaseDiffer(object):
                             partial(diff_worker_old_vs_new, id_list_old, new_db_col_names, cnt, diff_folder),
                         )
                         tg.create_task(diffed_old_vs_new(job))
-            except* Exception as eg:
+            except ExceptionGroup as eg:
                 raise first_exception(eg) from eg
             self.logger.info(
                 "Finished calculating diff for the old collection. Total number of docs deleted: %s",
@@ -436,7 +437,7 @@ class BaseDiffer(object):
                     if not os.path.basename(f).startswith("mapping")
                 ]
                 self.logger.info("%d diff files to process in total" % len(diff_files))
-                async with asyncio.TaskGroup() as tg:
+                async with TaskGroup() as tg:
                     while diff_files:
                         if len(diff_files) % 100 == 0:
                             self.logger.info("%d diff files to process" % len(diff_files))
@@ -475,7 +476,7 @@ class BaseDiffer(object):
             )
             try:
                 res = await merge_diff()
-            except* Exception as eg:
+            except ExceptionGroup as eg:
                 err = first_exception(eg)
                 self.logger.exception(
                     "Failed to reduce diff files: %s" % err,

--- a/biothings/hub/databuild/syncer.py
+++ b/biothings/hub/databuild/syncer.py
@@ -16,6 +16,7 @@ import biothings.utils.jsonpatch as jsonpatch
 from biothings import config as btconfig
 from biothings.hub import SYNCER_CATEGORY
 from biothings.hub.manager import BaseManager
+from biothings.utils.asyncio_compat import ExceptionGroup, TaskGroup
 from biothings.utils.common import first_exception, iter_n, loadobj, timesofar
 from biothings.utils.hub_db import get_src_build
 from biothings.utils.loggers import get_logger
@@ -253,7 +254,7 @@ class BaseSyncer(object):
                     summary[k] += res[k]
 
             try:
-                async with asyncio.TaskGroup() as tg:
+                async with TaskGroup() as tg:
                     for diff_file, worker_args in diff_files:
                         cnt += 1
                         pinfo["description"] = "file %s (%s/%s)" % (diff_file, cnt, total)
@@ -284,7 +285,7 @@ class BaseSyncer(object):
                             ),
                         )
                         tg.create_task(synced(job))
-            except* Exception as eg:
+            except ExceptionGroup as eg:
                 e = first_exception(eg)
                 self.register_status("failed", job={"err": repr(e)})
                 self.logger.error(

--- a/biothings/hub/dataindex/indexer.py
+++ b/biothings/hub/dataindex/indexer.py
@@ -16,6 +16,7 @@ from elasticsearch import AsyncElasticsearch
 from biothings import config as btconfig
 from biothings.hub import INDEXER_CATEGORY, INDEXMANAGER_CATEGORY
 from biothings.hub.databuild.backend import merge_src_build_metadata
+from biothings.utils.asyncio_compat import ExceptionGroup, TaskGroup
 from biothings.utils.common import (
     first_exception,
     get_class_from_classpath,
@@ -516,7 +517,7 @@ class Indexer:
             # when one batch fails, and job scheduling has not completed,
             # the TaskGroup stops scheduling and cancels all on-going jobs,
             # to fail quickly.
-            async with asyncio.TaskGroup() as tg:
+            async with TaskGroup() as tg:
                 for batch_num, ids in zip(schedule, id_provider):
                     await asyncio.sleep(0.0)
                     self.logger.info(schedule)
@@ -537,7 +538,7 @@ class Indexer:
                         batch_num,
                     )
                     tg.create_task(batch_finished(job))
-        except* Exception as eg:
+        except ExceptionGroup as eg:
             raise first_exception(eg) from eg
 
         self.logger.info(schedule)

--- a/biothings/hub/datainspect/inspector.py
+++ b/biothings/hub/datainspect/inspector.py
@@ -20,6 +20,7 @@ from biothings.hub.datainspect.doc_inspect import (
     stringify_inspect_doc,
 )
 from biothings.hub.manager import BaseManager
+from biothings.utils.asyncio_compat import ExceptionGroup, TaskGroup
 from biothings.utils.common import first_exception, timesofar
 from biothings.utils.dataload import dict_traverse
 from biothings.utils.hub_db import get_source_fullname, get_src_build, get_src_dump
@@ -244,7 +245,7 @@ class InspectorManager(BaseManager):
 
                 backend = create_backend(backend_provider).target_collection
                 try:
-                    async with asyncio.TaskGroup() as tg:
+                    async with TaskGroup() as tg:
                         for ids in id_feeder(backend, batch_size=batch_size):
                             if sample is not None:
                                 if random.random() > sample:
@@ -264,7 +265,7 @@ class InspectorManager(BaseManager):
                                 ),
                             )
                             tg.create_task(batch_inspected(job, cnt))
-                except* Exception as eg:
+                except ExceptionGroup as eg:
                     raise first_exception(eg) from eg
 
                 # compute metadata (they were skipped before)

--- a/biothings/hub/dataload/dumper.py
+++ b/biothings/hub/dataload/dumper.py
@@ -37,6 +37,7 @@ from biothings.hub import DUMPER_CATEGORY, UPLOADER_CATEGORY, renderer as job_re
 from biothings.hub.dataload.manager import BaseSourceManager
 from biothings.hub.dataload.uploader import set_pending_to_upload
 from biothings.hub.manager import ResourceError
+from biothings.utils.asyncio_compat import ExceptionGroup, TaskGroup
 from biothings.utils.common import first_exception, open_anyfile, rmdashfr, timesofar, untarall
 from biothings.utils.hub_db import get_src_dump
 from biothings.utils.loggers import get_logger
@@ -614,7 +615,7 @@ class BaseDumper:
             # 1. it prevents from launching things for nothing
             # 2. if we gathered errors at the end of the loop *and* if we
             #    had more errors than the queue size, we'd get stuck
-            async with asyncio.TaskGroup() as tg:
+            async with TaskGroup() as tg:
                 for todo in self.to_dump:
                     remote = todo["remote"]
                     local = todo["local"]
@@ -627,7 +628,7 @@ class BaseDumper:
                         await asyncio.sleep(courtesy_wait)
                     job = await job_manager.defer_to_process(pinfo, partial(self.download, remote, local))
                     tg.create_task(self._download_done(job, remote, local, max_dump))
-        except* Exception as eg:
+        except ExceptionGroup as eg:
             raise first_exception(eg) from eg
         self.logger.info("%s successfully downloaded" % self.SRC_NAME)
         self.to_dump = []

--- a/biothings/hub/dataload/uploader.py
+++ b/biothings/hub/dataload/uploader.py
@@ -10,8 +10,9 @@ from typing import Iterable, Optional
 
 from biothings import config
 from biothings.hub import BUILDER_CATEGORY, DUMPER_CATEGORY, UPLOADER_CATEGORY
-from biothings.hub.manager import ResourceNotFound
 from biothings.hub.dataload.manager import BaseSourceManager
+from biothings.hub.manager import ResourceNotFound
+from biothings.utils.asyncio_compat import ExceptionGroup, TaskGroup
 from biothings.utils.common import first_exception, get_random_string, get_timestamp, timesofar
 from biothings.utils.hub_db import get_src_conn, get_src_dump, get_src_master
 from biothings.utils.loggers import get_logger
@@ -698,7 +699,7 @@ class ParallelizedSourceUploader(BaseSourceUploader):
             # in other words: once unprepared, self should never be changed until all
             # jobs are submitted
             # (TaskGroup raises errors as soon as we know, cancelling the submission loop)
-            async with asyncio.TaskGroup() as tg:
+            async with TaskGroup() as tg:
                 for batch_number, args in enumerate(job_params):
                     pinfo = self.get_pinfo()
                     pinfo["step"] = "update_data"
@@ -727,7 +728,7 @@ class ParallelizedSourceUploader(BaseSourceUploader):
                     )
                     tg.create_task(batch_uploaded(job, fullname, batch_number))
                     submitted = True
-        except* Exception as eg:
+        except ExceptionGroup as eg:
             raise first_exception(eg) from eg
 
         if submitted:

--- a/biothings/utils/asyncio_compat.py
+++ b/biothings/utils/asyncio_compat.py
@@ -1,0 +1,12 @@
+"""Compatibility imports for structured asyncio concurrency."""
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from asyncio import TaskGroup
+    from builtins import BaseExceptionGroup, ExceptionGroup
+else:
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup
+    from taskgroup import TaskGroup
+
+__all__ = ["BaseExceptionGroup", "ExceptionGroup", "TaskGroup"]

--- a/biothings/utils/common.py
+++ b/biothings/utils/common.py
@@ -38,6 +38,8 @@ from shlex import shlex
 import requests
 import yaml
 
+from biothings.utils.asyncio_compat import BaseExceptionGroup, ExceptionGroup, TaskGroup
+
 try:
     import zstandard as zstd
 except ImportError:
@@ -934,12 +936,12 @@ async def aiogunzipall(folder, pattern, job_manager, pinfo):
 
     logging.info("Unzipping files in '%s'", folder)
     try:
-        async with asyncio.TaskGroup() as tg:
+        async with TaskGroup() as tg:
             for f in glob.glob(os.path.join(folder, pattern)):
                 pinfo["description"] = os.path.basename(f)
                 job = await job_manager.defer_to_process(pinfo, partial(gunzip, f, pattern=pattern))
                 tg.create_task(gunzip_one(job, f))
-    except* Exception as eg:
+    except ExceptionGroup as eg:
         raise first_exception(eg) from eg
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]    # version is dynamically generated from setup.py
 authors = [
     {name = "The BioThings Team", email="dev@biothings.io"},
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 description = "a toolkit for building high-performance data & knowledge APIs in biology"
 readme = "README.md"
 license = "Apache-2.0"
@@ -37,6 +37,7 @@ keywords = [
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -61,6 +62,8 @@ dependencies = [
     "jmespath>=0.7.1,<2.0.0",  # support jmespath query parameter
     "PyYAML>=5.1",
     "msgspec>=0.21.1",  # fast json lib supporting inf/nan and datetime; ships free-threaded (cp314t) wheels (replaced orjson, which re-enables the GIL on 3.14t)
+    'exceptiongroup; python_version<"3.11"',
+    'taskgroup>=0.2.2; python_version<"3.11"',
     'zstandard>=0.21.0; python_version<"3.14"', # we need zst library before 3.14
 ]
 

--- a/tests/benchmarks/bench_jobmanager.py
+++ b/tests/benchmarks/bench_jobmanager.py
@@ -27,6 +27,8 @@ import tempfile
 import time
 from functools import partial
 
+from biothings.utils.asyncio_compat import TaskGroup
+
 
 def setup_config(workers):
     # minimal hub configuration so biothings.utils.manager can be imported
@@ -109,7 +111,7 @@ async def run_bench(jm, batches, num_docs, width):
         done += res
 
     t0 = time.time()
-    async with asyncio.TaskGroup() as tg:
+    async with TaskGroup() as tg:
         for b in range(batches):
             job = await jm.defer_to_process(dict(pinfo), partial(merge_batch, num_docs, width, b))
             tg.create_task(watch(job))

--- a/tests/utils/test_asyncio_compat.py
+++ b/tests/utils/test_asyncio_compat.py
@@ -1,0 +1,31 @@
+import asyncio
+
+import pytest
+
+from biothings.utils.asyncio_compat import ExceptionGroup, TaskGroup
+from biothings.utils.common import first_exception
+
+
+@pytest.mark.asyncio
+async def test_taskgroup_cancels_siblings_and_groups_failures():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def sibling():
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            cancelled.set()
+
+    async def fail():
+        await started.wait()
+        raise ValueError("worker failure")
+
+    with pytest.raises(ExceptionGroup) as raised:
+        async with TaskGroup() as group:
+            group.create_task(sibling())
+            group.create_task(fail())
+
+    assert isinstance(first_exception(raised.value), ValueError)
+    assert cancelled.is_set()

--- a/tests/web/test_serializer.py
+++ b/tests/web/test_serializer.py
@@ -4,17 +4,20 @@ from biothings.web.handlers import serializer
 def test_json_01():
     import json
     from collections import UserDict, UserList
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     obj = {
         "key1": "val1",
-        "key2": datetime.now().astimezone(),
+        "key2": datetime.now(timezone.utc),
         "key3": UserDict({"key3.1": "val3.1"}),
         "key4": UserList(["val4.1", "val4.2"]),
     }
     json_str = serializer.to_json(obj)
     obj2 = json.loads(json_str)
-    obj2["key2"] = datetime.fromisoformat(obj2["key2"])
+    datetime_str = obj2["key2"]
+    if datetime_str.endswith("Z"):
+        datetime_str = f"{datetime_str[:-1]}+00:00"
+    obj2["key2"] = datetime.fromisoformat(datetime_str)
     assert obj2 == obj
 
 


### PR DESCRIPTION
## Summary

- restore Python 3.10 package metadata and CI coverage
- add conditional `taskgroup` and `exceptiongroup` backports for Python 3.10
- route structured-concurrency call sites through a compatibility module while retaining native asyncio classes on Python 3.11+
- add a regression test covering sibling cancellation and grouped failures

## Why

The asyncio modernization moved the package baseline to Python 3.11 because the hub now uses `asyncio.TaskGroup`, exception groups, and `except*`. The remaining runtime and dependency surface is compatible with Python 3.10, so a small compatibility layer is sufficient to restore support without changing the free-threaded Python path.

## Impact

Python 3.10 can install and run the SDK again. Python 3.11+ continues using the standard-library structured-concurrency implementation, and free-threaded Python behavior is unchanged.

## Validation

- Python 3.10.4 package install with `.[web_extra,hub,docker_ssh,cli,dev]`
- `pip check`
- package metadata verified as `Requires-Python: >=3.10`
- full Python 3.10 suite: 422 passed, 75 skipped, 18 xfailed
- Python 3.11 native compatibility-path check
- Python 3.10 syntax parse across `biothings` and `tests`
