### PR TITLE
Fix inspection mapping quick index flow

### DIFF
--- a/biothings/hub/databuild/builder.py
+++ b/biothings/hub/databuild/builder.py
@@ -532,9 +532,11 @@ class DataBuilder:
                 raise BuilderException(
                     "'%s'could not be found in master documents (%s)" % (src, repr(list(masters.keys())))
                 )
-            search = src
-            if master["_id"] != master["name"]:
-                search = master["name"]
+            # A mapping saved from inspection can be the first src_master data
+            # recorded for a source. Older/minimal records only contain ``_id``
+            # and ``mapping``; in that case the source id is also the exact
+            # collection-name pattern.
+            search = master.get("name", master["_id"])
             # restrict pattern to minimal match
             pat = re.compile("^%s$" % search)
             for col in cols:
@@ -1335,11 +1337,13 @@ class BuilderManager(BaseManager):
         to store to merge data. If none, each call will generate a unique target_name.
         """
         try:
-            bdr = self[build_name]
-            job = bdr.merge(sources, target_name, job_manager=self.job_manager, **kwargs)
-            return job
+            builder_factory = BaseManager.__getitem__(self, build_name)
         except KeyError as key_error:
             raise BuilderException("No such builder for '%s'" % build_name) from key_error
+
+        bdr = builder_factory()
+        try:
+            return bdr.merge(sources, target_name, job_manager=self.job_manager, **kwargs)
         except ResourceNotReady as resource_error:
             raise BuilderException(f"Some datasources aren't ready for the merge: {resource_error}") from resource_error
 

--- a/biothings/hub/datainspect/inspector.py
+++ b/biothings/hub/datainspect/inspector.py
@@ -334,9 +334,16 @@ class InspectorManager(BaseManager):
         if data_provider_type == "source":
             src_sources_inspect_data = registerer_obj.src_doc.get("inspect", {}).get("jobs", {})
             for src_source_name, inspect_data in src_sources_inspect_data.items():
+                inspect_results = inspect_data.get("inspect", {}).get("results")
+                if inspect_results is None:
+                    self.logger.debug(
+                        "Skipping inspection data for source '%s': no completed results are available (status: %s)",
+                        src_source_name,
+                        inspect_data.get("status"),
+                    )
+                    continue
                 results[src_source_name] = {
-                    _mode: flatten_and_validate(inspect_data["inspect"]["results"].get(_mode) or {}, do_validate)
-                    for _mode in mode
+                    _mode: flatten_and_validate(inspect_results.get(_mode) or {}, do_validate) for _mode in mode
                 }
         else:
             inspect_data = registerer_obj.src_build.get("inspect", {}).get("results", {})

--- a/biothings/hub/dataload/source.py
+++ b/biothings/hub/dataload/source.py
@@ -358,7 +358,7 @@ class SourceManager(BaseSourceManager):
         except IndexError:
             subsrc = name
         if dest == "master":
-            m = self.src_master.find_one({"_id": subsrc}) or {"_id": subsrc}
+            m = self.src_master.find_one({"_id": subsrc}) or {"_id": subsrc, "name": subsrc}
             m["mapping"] = mapping
             self.src_master.save(m)
         elif dest == "inspect":


### PR DESCRIPTION
## Problem

During 1.2.x testing on free-threaded Python 3.14t, source mapping inspection completed its batch workers, but the subsequent `PUT /flatten_inspection_data` request failed with:

```text
KeyError: 'inspect'
```

After inspecting and saving the generated mapping, a quick index that had previously worked then failed with:

```text
No such builder for 'geneinfo_configuration_<timestamp>_<random>'
```

These are two related state-handling problems. The inspection failure leaves the mapping workflow in a bad state, while saving a mapping can expose incomplete source-master metadata used by quick index. The reported quick-index error is also misleading because the temporary builder was created successfully.

## Is inspection itself unsafe in free-threaded mode?

There is no evidence in this trace that the free-threaded workers corrupt or concurrently merge inspection data.

Each worker computes an isolated batch result. `batch_inspected()` awaits that result and merges it into the aggregate on the asyncio event-loop thread. Those merge callbacks therefore remain serialized even when `defer_to_process()` is backed by the free-threaded `ThreadPoolExecutor`. The surrounding `TaskGroup` is awaited before final Elasticsearch mapping generation and before the inspection status/results are persisted.

The `Remove PID file ... FTWorker_*` messages only mean that each worker function has returned. They do not mean that event-loop aggregation, mapping generation, metadata conversion, or the final status write has completed. Consequently, a flatten request may still observe an inspection job in an intermediate state with a status such as `inspecting` but without `inspect.results` yet.

The same incomplete state can also exist after a failed/canceled inspection or in another subsource job stored in the same source document. `flatten()` iterates all of those jobs and previously assumed every entry had a completed result. Free-threaded execution makes this timing easier to encounter, but the unsafe assumption is not specific to the free-threaded executor or to `TaskGroup`.

This PR does not change worker scheduling, asyncio aggregation, or inspection calculation. It makes the consumer tolerate valid non-complete job states while preserving completed results.

## Inspection fix

For source inspection, `InspectorManager.flatten()` now:

- reads `inspect.results` defensively;
- omits jobs that have no completed result instead of raising `KeyError`;
- logs the skipped source job and its current status at debug level; and
- continues returning completed results from other jobs in the same source document.

Build inspection is unaffected. It already reads a single build result with `.get(..., {})` rather than iterating source job records.

No empty or fabricated mapping is returned for an in-progress/failed job; that job is simply absent from the flattened response until a completed result exists.

## Why quick index fails only after the mapping workflow

Quick index creates a temporary build configuration and asks `DataBuilder.resolve_sources()` to resolve each configured source through `src_master`.

A normal upload creates a complete master document containing both `_id` and `name`, so quick index works before inspection. However, when a generated inspection mapping is saved to `dest="master"` and no master document exists yet, `SourceManager.save_mapping()` previously created only:

```python
{"_id": subsource, "mapping": mapping}
```

`resolve_sources()` then accessed `master["name"]`, raising `KeyError`. `BuilderManager.merge()` caught that unrelated `KeyError` and rewrote it as `No such builder for <temporary configuration>`, even though the temporary builder was present. This is why the visible error names the generated build configuration rather than the missing source metadata field.

## Quick-index coverage

| Flow | Result with this PR |
| --- | --- |
| Quick index before mapping inspection | Unchanged; continues to use the complete uploader-created master document. |
| Save an inspected mapping into a new master record, then quick index | Fixed; new records now include `name`. |
| Quick index with an existing legacy/minimal master record lacking `name` | Fixed; source resolution falls back to `_id`. |
| Quick index for a main source | Fixed through the same source-resolution path. |
| Quick index with an explicit `subsource` | Fixed through the same source-resolution path. |
| Regex-based source master with `_id != name` | Unchanged; the explicit `name` regex is still used. |
| Save mapping only to `dest="inspect"` | Unchanged; this destination does not create or modify the source-master record. |

The fallback assumes the minimal record's `_id` is the exact collection name, which is how `save_mapping()` derives the id for a non-regex source. Existing regex-aware records retain and use their explicit `name`.

## Changes

1. Skip source inspection jobs that do not yet contain completed `inspect.results` when flattening.
2. Include `name` when saving a mapping creates a source-master record for the first time.
3. Fall back from missing `src_master.name` to `src_master._id`, so records created by older versions are also usable without migration.
4. Restrict the `No such builder` translation to the actual builder registry lookup. A `KeyError` raised while constructing or starting a merge now retains its real context.

## Validation

- `pytest tests/hub/datainspect tests/hub/databuild tests/hub/dataload` — 50 passed
- `pytest tests/utils/test_manager.py` — 12 passed, including the existing free-threaded executor opt-in and distinct worker tracking-file coverage
- `black --check --fast biothings/hub/datainspect/inspector.py biothings/hub/dataload/source.py biothings/hub/databuild/builder.py` — passed

The exact reported dataset/workflow was not reproduced end-to-end under a local 3.14t runtime. Validation covers the affected managers and existing free-threaded JobManager behavior. No new test files are included in this PR.
