### PR TITLE
Fix cached indexing client lifecycle

### DIFF
--- a/biothings/hub/dataindex/indexer_task.py
+++ b/biothings/hub/dataindex/indexer_task.py
@@ -236,16 +236,6 @@ class IndexingTask:
         clients.mongo = self.backend.mongo()
         return clients
 
-    def _close_clients(self, clients):
-        es_client = getattr(clients.es, "client", None)
-        if es_client and hasattr(es_client, "close"):
-            es_client.close()
-
-        mongo_database = getattr(clients.mongo, "database", None)
-        mongo_client = getattr(mongo_database, "client", None)
-        if mongo_client and hasattr(mongo_client, "close"):
-            mongo_client.close()
-
     def dispatch(self):
         if self.mode in (Mode.INDEX, Mode.PURGE):
             return self.index()
@@ -256,11 +246,8 @@ class IndexingTask:
 
     def index(self):
         clients = self._get_clients()
-        try:
-            count_docs = self._index_ids(clients, self.ids)
-            return count_docs + len(self.invalid_ids)
-        finally:
-            self._close_clients(clients)
+        count_docs = self._index_ids(clients, self.ids)
+        return count_docs + len(self.invalid_ids)
 
     def _index_ids(self, clients, ids):
         if not ids:
@@ -276,50 +263,44 @@ class IndexingTask:
 
     def merge(self):
         clients = self._get_clients()
-        try:
-            upd_cnt, docs_old = 0, {}
-            new_cnt, docs_new = 0, {}
+        upd_cnt, docs_old = 0, {}
+        new_cnt, docs_new = 0, {}
 
-            # populate docs_old
-            for doc in clients.es.mget(self.ids):
-                docs_old[doc["_id"]] = doc
+        # populate docs_old
+        for doc in clients.es.mget(self.ids):
+            docs_old[doc["_id"]] = doc
 
-            # populate docs_new
-            for doc in doc_feeder(
-                clients.mongo,
-                step=len(self.ids),
-                inbatch=False,
-                query={"_id": {"$in": self.ids}},
-            ):
-                docs_new[doc["_id"]] = doc
-                doc.pop("_timestamp", None)
+        # populate docs_new
+        for doc in doc_feeder(
+            clients.mongo,
+            step=len(self.ids),
+            inbatch=False,
+            query={"_id": {"$in": self.ids}},
+        ):
+            docs_new[doc["_id"]] = doc
+            doc.pop("_timestamp", None)
 
-            # merge existing ids
-            for key in list(docs_new):
-                if key in docs_old:
-                    docs_old[key].update(docs_new[key])
-                    del docs_new[key]
+        # merge existing ids
+        for key in list(docs_new):
+            if key in docs_old:
+                docs_old[key].update(docs_new[key])
+                del docs_new[key]
 
-            # updated docs (those existing in col *and* index)
-            upd_cnt = clients.es.mindex(docs_old.values())
-            self.logger.info("%s: %d documents updated.", self.name, upd_cnt)
+        # updated docs (those existing in col *and* index)
+        upd_cnt = clients.es.mindex(docs_old.values())
+        self.logger.info("%s: %d documents updated.", self.name, upd_cnt)
 
-            # new docs (only in col, *not* in index)
-            new_cnt = clients.es.mindex(docs_new.values())
-            self.logger.info("%s: %d new documents.", self.name, new_cnt)
+        # new docs (only in col, *not* in index)
+        new_cnt = clients.es.mindex(docs_new.values())
+        self.logger.info("%s: %d new documents.", self.name, new_cnt)
 
-            return upd_cnt + new_cnt
-        finally:
-            self._close_clients(clients)
+        return upd_cnt + new_cnt
 
     def resume(self):
         clients = self._get_clients()
-        try:
-            count_ids = len(self.ids) + len(self.invalid_ids)
-            missing_ids = [x.id for x in clients.es.mexists(self.ids) if not x.exists]
-            self.logger.info("%s: %d missing documents.", self.name, len(missing_ids))
-            if missing_ids:
-                self._index_ids(clients, missing_ids)
-            return count_ids
-        finally:
-            self._close_clients(clients)
+        count_ids = len(self.ids) + len(self.invalid_ids)
+        missing_ids = [x.id for x in clients.es.mexists(self.ids) if not x.exists]
+        self.logger.info("%s: %d missing documents.", self.name, len(missing_ids))
+        if missing_ids:
+            self._index_ids(clients, missing_ids)
+        return count_ids

--- a/tests/hub/dataindex/test_indexer_task.py
+++ b/tests/hub/dataindex/test_indexer_task.py
@@ -1,61 +1,238 @@
-"""
-Tests the indexer ability through elasticsearch
-"""
+import copy
+import importlib
+from functools import partial
+from types import SimpleNamespace
 
-from typing import Callable, Tuple
-
-import elasticsearch
 import pytest
 
 
-@pytest.mark.xfail(reason="WIP: Have to figure out mongoDB / elasticsearch setup")
-def test_task_index(task_clients: Tuple[Callable, Callable]):
-    from biothings.hub.dataindex.indexer_task import IndexingTask
-
-    task = IndexingTask(
-        es=task_clients[0],
-        mongo=task_clients[1],
-        ids=("0999b13cb8026aba", "1111647aaf9c70b4", "1c9828073bad510c"),
+@pytest.fixture
+def indexer_task_module(root_configuration, tmp_path):
+    root_configuration.override(
+        {
+            "__file__": str(tmp_path / "test_config.py"),
+            "HUB_DB_BACKEND": {
+                "module": "biothings.utils.sqlite3",
+                "sqlite_db_folder": str(tmp_path),
+            },
+            "DATA_HUB_DB_DATABASE": "indexer_task_hubdb",
+        }
     )
-    task.index()
+
+    importlib.import_module("biothings.hub")._config_for_app(root_configuration)
+    yield importlib.import_module("biothings.hub.dataindex.indexer_task")
+
+    root_configuration.reset()
 
 
-@pytest.mark.xfail(reason="WIP: Have to figure out mongoDB / elasticsearch setup")
-def test_task_resume(task_clients: Tuple[Callable, Callable]):
-    from biothings.hub.dataindex.indexer_task import IndexingTask
+class FakeMongoCollection:
+    def __init__(self, database, name, documents):
+        self.database = database
+        self.name = name
+        self.documents = documents
 
-    task = IndexingTask(
-        es=task_clients[0],
-        mongo=task_clients[1],
-        ids=(
-            "0999b13cb8026aba",
-            "1111647aaf9c70b4",
-            "1c9828073bad510c",
-            "1f447d7fc6dcc2cf",
-            "27e81a308e4e04da",
+
+class FakeMongoDatabase:
+    def __init__(self, client, documents):
+        self.client = client
+        self.documents = documents
+        self.collections = {}
+
+    def __getitem__(self, name):
+        self.client.ensure_open()
+        return self.collections.setdefault(name, FakeMongoCollection(self, name, self.documents))
+
+
+class FakeMongoClient:
+    def __init__(self, documents):
+        self.documents = {doc["_id"]: copy.deepcopy(doc) for doc in documents}
+        self.databases = {}
+        self.closed = False
+        self.close_calls = 0
+
+    def __getitem__(self, name):
+        self.ensure_open()
+        return self.databases.setdefault(name, FakeMongoDatabase(self, self.documents))
+
+    def ensure_open(self):
+        if self.closed:
+            raise RuntimeError("Cannot use fake MongoClient after close")
+
+    def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+
+class FakeElasticsearchClient:
+    def __init__(self, documents):
+        self.documents = {doc["_id"]: copy.deepcopy(doc) for doc in documents}
+        self.closed = False
+        self.close_calls = 0
+
+    def ensure_open(self):
+        if self.closed:
+            raise RuntimeError("Cannot use fake Elasticsearch client after close")
+
+    def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+
+class FakeESIndex:
+    def __init__(self, client, index_name, **bulk_index_args):
+        self.client = client
+        self.index_name = index_name
+
+    def mget(self, ids):
+        self.client.ensure_open()
+        for _id in ids:
+            if _id in self.client.documents:
+                yield copy.deepcopy(self.client.documents[_id])
+
+    def mexists(self, ids):
+        self.client.ensure_open()
+        for _id in ids:
+            yield SimpleNamespace(id=_id, exists=_id in self.client.documents)
+
+    def mindex(self, docs):
+        self.client.ensure_open()
+        docs = list(docs)
+        for doc in docs:
+            self.client.documents[doc["_id"]] = copy.deepcopy(doc)
+        return len(docs)
+
+
+def make_cached_backends(monkeypatch, indexer_task_module, source_documents, indexed_documents=()):
+    from biothings.utils import mongo as mongo_utils
+
+    mongo_clients = []
+    es_clients = []
+
+    def make_mongo_client(**kwargs):
+        client = FakeMongoClient(source_documents)
+        mongo_clients.append(client)
+        return client
+
+    def make_es_client(**kwargs):
+        client = FakeElasticsearchClient(indexed_documents)
+        es_clients.append(client)
+        return client
+
+    def fake_doc_feeder(collection, *, query, **kwargs):
+        collection.database.client.ensure_open()
+        for _id in query["_id"]["$in"]:
+            if _id in collection.documents:
+                yield copy.deepcopy(collection.documents[_id])
+
+    monkeypatch.setattr(mongo_utils, "_client_cache", {})
+    monkeypatch.setattr(indexer_task_module, "MongoClient", make_mongo_client)
+    monkeypatch.setattr(indexer_task_module, "Elasticsearch", make_es_client)
+    monkeypatch.setattr(indexer_task_module, "ESIndex", FakeESIndex)
+    monkeypatch.setattr(indexer_task_module, "doc_feeder", fake_doc_feeder)
+
+    return SimpleNamespace(
+        module=indexer_task_module,
+        es=partial(
+            indexer_task_module._get_es_client,
+            {"hosts": ["http://fake-elasticsearch:9200"]},
+            {},
+            "test-index",
         ),
+        mongo=partial(
+            indexer_task_module._get_mg_client,
+            {"host": "fake-mongodb", "port": 27017},
+            "test-database",
+            "test-collection",
+        ),
+        es_clients=es_clients,
+        mongo_clients=mongo_clients,
     )
-    task.resume()
 
 
-@pytest.mark.xfail(reason="WIP: Have to figure out mongoDB / elasticsearch setup")
-def test_elasticsearch_index():
-    from biothings.hub.dataindex.indexer_task import ESIndex
+def run_sequential_tasks(backends, mode, batches):
+    counts = []
+    for ids in batches:
+        task = backends.module.IndexingTask(backends.es, backends.mongo, ids, mode=mode)
+        counts.append(task.dispatch())
 
-    elasticsearch_host = "http://localhost:9200"
-    index_name = "mynews_202105261855_5ffxvchx"
-    elasticsearch_client = elasticsearch.Elasticsearch(hosts=elasticsearch_host)
-    index_instance = ESIndex(elasticsearch_client, index_name)
-    print(index_instance.doc_type)
-    print(
-        list(
-            index_instance.mget(
-                [
-                    "0999b13cb8026aba",
-                    "1111647aaf9c70b4",
-                    "________________",
-                ]
-            )
-        )
+        assert len(backends.es_clients) == 1
+        assert len(backends.mongo_clients) == 1
+        assert backends.es_clients[0].closed is False
+        assert backends.mongo_clients[0].closed is False
+        assert backends.es_clients[0].close_calls == 0
+        assert backends.mongo_clients[0].close_calls == 0
+
+    assert backends.es().client is backends.es_clients[0]
+    assert backends.mongo().database.client is backends.mongo_clients[0]
+    return counts
+
+
+def test_index_tasks_reuse_cached_clients_without_closing_them(monkeypatch, indexer_task_module):
+    too_long_id = "x" * 513
+    source_documents = [
+        {"_id": "index-1", "value": 1},
+        {"_id": "index-2", "value": 2},
+    ]
+    backends = make_cached_backends(monkeypatch, indexer_task_module, source_documents)
+
+    counts = run_sequential_tasks(backends, "index", [("index-1",), ("index-2", too_long_id)])
+
+    assert counts == [1, 2]
+    assert backends.es_clients[0].documents == {
+        "index-1": {"_id": "index-1", "value": 1},
+        "index-2": {"_id": "index-2", "value": 2},
+    }
+
+
+def test_merge_tasks_reuse_cached_clients_without_closing_them(monkeypatch, indexer_task_module):
+    source_documents = [
+        {"_id": "existing-1", "value": "new-1", "_timestamp": "ignored"},
+        {"_id": "new-1", "value": "new-1", "_timestamp": "ignored"},
+        {"_id": "existing-2", "value": "new-2", "_timestamp": "ignored"},
+        {"_id": "new-2", "value": "new-2", "_timestamp": "ignored"},
+    ]
+    indexed_documents = [
+        {"_id": "existing-1", "value": "old", "preserved": 1},
+        {"_id": "existing-2", "value": "old", "preserved": 2},
+    ]
+    backends = make_cached_backends(monkeypatch, indexer_task_module, source_documents, indexed_documents)
+
+    counts = run_sequential_tasks(
+        backends,
+        "merge",
+        [("existing-1", "new-1"), ("existing-2", "new-2")],
     )
-    print(list(index_instance.mexists(["0999b13cb8026aba", "1111647aaf9c70b4", "________________"])))
+
+    assert counts == [2, 2]
+    assert backends.es_clients[0].documents == {
+        "existing-1": {"_id": "existing-1", "value": "new-1", "preserved": 1},
+        "new-1": {"_id": "new-1", "value": "new-1"},
+        "existing-2": {"_id": "existing-2", "value": "new-2", "preserved": 2},
+        "new-2": {"_id": "new-2", "value": "new-2"},
+    }
+
+
+def test_resume_tasks_reuse_cached_clients_without_closing_them(monkeypatch, indexer_task_module):
+    source_documents = [
+        {"_id": "missing-1", "value": 1},
+        {"_id": "missing-2", "value": 2},
+    ]
+    indexed_documents = [
+        {"_id": "existing-1", "value": "preserved-1"},
+        {"_id": "existing-2", "value": "preserved-2"},
+    ]
+    backends = make_cached_backends(monkeypatch, indexer_task_module, source_documents, indexed_documents)
+
+    counts = run_sequential_tasks(
+        backends,
+        "resume",
+        [("existing-1", "missing-1"), ("existing-2", "missing-2")],
+    )
+
+    assert counts == [2, 2]
+    assert backends.es_clients[0].documents == {
+        "existing-1": {"_id": "existing-1", "value": "preserved-1"},
+        "missing-1": {"_id": "missing-1", "value": 1},
+        "existing-2": {"_id": "existing-2", "value": "preserved-2"},
+        "missing-2": {"_id": "missing-2", "value": 2},
+    }


### PR DESCRIPTION
## Summary

- keep the process-local MongoDB and Elasticsearch client caches
- stop `IndexingTask.index()`, `merge()`, and `resume()` from closing cached clients after each batch
- remove the obsolete `_close_clients()` helper
- replace the live-service WIP indexing-task tests with deterministic fake-client regressions

## Root cause

`_get_mg_client()` and `_get_es_client()` return process-local cached clients, but each indexing task still treated those clients as task-owned resources. The task-level `finally` blocks closed the cached clients after a successful batch. When the same worker processed another batch, `cached_client()` returned the same now-closed object, causing PyMongo to raise `InvalidOperation: Cannot use MongoClient after close`. Elasticsearch had the same ownership conflict.

The cache owns the connection-pool clients. Individual indexing batches borrow them and must leave them usable for subsequent work in that process. Any explicit closure belongs at worker or process shutdown.

## Regression coverage

The updated tests use fake MongoDB and Elasticsearch clients and require no live services. For `index`, `merge`, and `resume`, they verify that:

- two sequential tasks in one process reuse the same cached clients
- completing the first task does not close or invalidate either client
- neither client is closed after an individual batch
- established return counts and indexed document behavior are preserved

## Testing

- `.venv/bin/pytest tests/hub/dataindex/test_indexer_task.py` — 3 passed
- `.venv/bin/pytest tests/hub/dataindex/test_indexer_task.py tests/hub/dataindex/test_indexer_lifecycle.py` — 7 passed
- `.venv/bin/black --check biothings/hub/dataindex/indexer_task.py tests/hub/dataindex/test_indexer_task.py` — passed
- `.venv/bin/pytest tests/utils/` — collection blocked by the existing test configuration attempting to connect to Elasticsearch at `localhost:9200` from `tests/utils/test_manager.py`
