### PR TITLE
Add query validation to prevent known input errors

### DIFF
--- a/biothings/web/query/formatter.py
+++ b/biothings/web/query/formatter.py
@@ -19,18 +19,14 @@ from biothings.utils.jmespath import options as jmp_options
 logger = logging.getLogger(__name__)
 
 # Substrings identifying Elasticsearch error reasons that are caused by user
-# input (typically mapping problems: sorting/aggregating/collapsing on a field
-# that isn't mapped or isn't the right type). These are the client's fault, not
-# a server-side bug, so they are logged below ERROR to avoid noisy Sentry
-# reports. Any other reasoned error stays at ERROR so it is still reported.
 _ES_CLIENT_ERROR_REASONS = (
     "no mapping found for",  # e.g. "No mapping found for [score] in order to sort on"
     "fielddata is disabled",  # e.g. sorting/aggregating on an analyzed text field
+    "failed to parse query",  # e.g. "Failed to parse query [entrezgene:-]"
 )
 
 
 def _is_es_client_error_reason(reason):
-    """Return True if `reason` is a known user-input (mapping) error."""
     reason = (reason or "").lower()
     return any(pattern in reason for pattern in _ES_CLIENT_ERROR_REASONS)
 
@@ -118,8 +114,8 @@ class ESResultFormatter(ResultFormatter):
 
                 if reason:
                     if _is_es_client_error_reason(reason):
-                        # known user-input (mapping) error -> log below ERROR so
-                        # it is not captured as a Sentry event.
+                        # known user-input error -> log below ERROR so it is
+                        # not captured as a Sentry event.
                         logger.warning("ES returned client error response: %s", self.data)
                     else:
                         # a reasoned error we don't recognize as user-caused ->

--- a/tests/web/query/test_formatter.py
+++ b/tests/web/query/test_formatter.py
@@ -43,6 +43,7 @@ def test_es_mapping_errors_logged_below_error(caplog):
     for reason in (
         "No mapping found for [score] in order to sort on",
         "Fielddata is disabled on [name] in [my_index]. Text fields are not optimised for sorting...",
+        "Failed to parse query [entrezgene:-]",
     ):
         caplog.clear()
         with caplog.at_level(logging.DEBUG), pytest.raises(ValueError) as exc_info:


### PR DESCRIPTION
This pull request updates the handling and logging of Elasticsearch client errors in the `biothings/web/query/formatter.py` module. The main change is the addition of a new error pattern to better capture user-caused errors and ensure they are logged appropriately, along with corresponding updates to tests.

**Elasticsearch client error handling:**

* Added "failed to parse query" to the list of known user-caused Elasticsearch error reasons (`_ES_CLIENT_ERROR_REASONS`), so these errors are now logged at the warning level instead of error, preventing unnecessary Sentry alerts.
* Updated the comment to reflect that user-input errors are not limited to mapping problems.

**Testing improvements:**

* Added a new test case for the "Failed to parse query" error reason in `test_es_mapping_errors_logged_below_error` to ensure it is handled and logged as a client error.