### PR TITLE
Release v1.1.4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+v1.1.4 (2026/09/10)
+    biothings.web improvements:
+        - Rejected `_id` as a sort or aggregation field with an actionable error message instead of an Elasticsearch fielddata failure. ([1747825](https://github.com/biothings/biothings.api/commit/17478250478b8e45458b56ca0ca8f8fa174ced97))
+        - Reduced Sentry noise for Elasticsearch query-parse failures caused by malformed user queries, covering both single-node and multi-node cluster error shapes. ([#466](https://github.com/biothings/biothings.api/pull/466), [9d71063](https://github.com/biothings/biothings.api/commit/9d710634c71d9a8580901fc46f138a10e5903775))
+        - Limited POST query batches to a maximum of 5000 query terms. ([e733d28](https://github.com/biothings/biothings.api/commit/e733d28987b7ca5f67347573c2b584f4cd146537))
+        - Lowered query-object parser logging from INFO to DEBUG. ([9d71063](https://github.com/biothings/biothings.api/commit/9d710634c71d9a8580901fc46f138a10e5903775))
+
+    Misc improvements:
+        - Added tests covering POST query batch limits. ([c5e00b8](https://github.com/biothings/biothings.api/commit/c5e00b88daaedca4f65ce6c5220b5a918887088f))
+
 v1.1.3 (2026/08/13)
     biothings.web improvements:
         - Reduced Sentry noise for known Elasticsearch mapping errors by logging them below ERROR while preserving error reporting for unexpected responses. ([3257d21](https://github.com/biothings/biothings.api/commit/3257d212baca228164318339157e84dd40daf8df), [371122c](https://github.com/biothings/biothings.api/commit/371122c78121c742e1608dddbd5edc79b27c575c))

--- a/biothings/__init__.py
+++ b/biothings/__init__.py
@@ -8,7 +8,7 @@ class _version_info(NamedTuple):
     micro: int
 
 
-version_info = _version_info(1, 1, 3)
+version_info = _version_info(1, 1, 4)
 __version__ = ".".join(map(str, version_info))
 
 

--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -385,7 +385,7 @@ class QStringParser:
                     scope_fields = [scope_fields]
 
                 query_object = Query(term_query, scope_fields)
-                logger.info("Regex match generated query object: [%s]", query_object)
+                logger.debug("Regex match generated query object: [%s]", query_object)
                 break
 
         if query_metadata is not None:
@@ -409,7 +409,7 @@ class QStringParser:
             query_object = Query(query, fallback_scope_fields)
             logger.debug("No regex pattern match found. Setting query object instance to default [%s]", query_object)
 
-        logger.info("Generated query object: [%s]", query_object)
+        logger.debug("Generated query object: [%s]", query_object)
         return query_object
 
 

--- a/biothings/web/query/builder.py
+++ b/biothings/web/query/builder.py
@@ -53,6 +53,8 @@ MAX_RESULT_WINDOW = 10000
 
 ES_DEFAULT_SIZE = 10
 
+_ID_FIELDDATA_ERROR = "Cannot {operation} the '_id' field: it is not available for sorting or aggregation."
+
 
 class RawQueryInterrupt(Exception):
     def __init__(self, data):
@@ -746,6 +748,10 @@ class ESQueryBuilder:
                     "Use a comma-separated list of fields, each optionally "
                     'prefixed with "-" for descending order, e.g. sort=-taxid,symbol.'
                 )
+            # the field name without any ':order' suffix, so '_id', '-_id' and
+            # '_id:desc' are all recognized as sorting on _id
+            if name.partition(":")[0] == "_id":
+                raise ValueError(_ID_FIELDDATA_ERROR.format(operation="sort on"))
             if ":" in name:
                 _field, _, _order = name.partition(":")
                 if _field == "_score":
@@ -760,8 +766,7 @@ class ESQueryBuilder:
                 )
             if descending and name == "_score":
                 # elasticsearch-dsl raises IllegalOperation for '-_score' because
-                # relevance already sorts descending. Reject it here so the user
-                # gets an actionable message and no ERROR-level log is emitted.
+                # relevance already sorts descending.
                 raise ValueError(
                     "Invalid sort field '-_score': relevance is already sorted in "
                     "descending order, so the '-' prefix is not supported here. "
@@ -807,6 +812,8 @@ class ESQueryBuilder:
                     _term, term = term[:-1].split("(", 1)
                 else:
                     _term, term = term, ""
+                if _term == "_id":
+                    raise ValueError(_ID_FIELDDATA_ERROR.format(operation="aggregate on"))
                 bucket = bucket.bucket(_term, "terms", field=_term, size=facet_size)
 
         # add es params

--- a/biothings/web/query/formatter.py
+++ b/biothings/web/query/formatter.py
@@ -19,18 +19,14 @@ from biothings.utils.jmespath import options as jmp_options
 logger = logging.getLogger(__name__)
 
 # Substrings identifying Elasticsearch error reasons that are caused by user
-# input (typically mapping problems: sorting/aggregating/collapsing on a field
-# that isn't mapped or isn't the right type). These are the client's fault, not
-# a server-side bug, so they are logged below ERROR to avoid noisy Sentry
-# reports. Any other reasoned error stays at ERROR so it is still reported.
 _ES_CLIENT_ERROR_REASONS = (
     "no mapping found for",  # e.g. "No mapping found for [score] in order to sort on"
     "fielddata is disabled",  # e.g. sorting/aggregating on an analyzed text field
+    "failed to parse query",  # e.g. "Failed to parse query [entrezgene:-]"
 )
 
 
 def _is_es_client_error_reason(reason):
-    """Return True if `reason` is a known user-input (mapping) error."""
     reason = (reason or "").lower()
     return any(pattern in reason for pattern in _ES_CLIENT_ERROR_REASONS)
 
@@ -118,8 +114,8 @@ class ESResultFormatter(ResultFormatter):
 
                 if reason:
                     if _is_es_client_error_reason(reason):
-                        # known user-input (mapping) error -> log below ERROR so
-                        # it is not captured as a Sentry event.
+                        # known user-input error -> log below ERROR so it is
+                        # not captured as a Sentry event.
                         logger.warning("ES returned client error response: %s", self.data)
                     else:
                         # a reasoned error we don't recognize as user-caused ->

--- a/biothings/web/query/formatter.py
+++ b/biothings/web/query/formatter.py
@@ -19,10 +19,19 @@ from biothings.utils.jmespath import options as jmp_options
 logger = logging.getLogger(__name__)
 
 # Substrings identifying Elasticsearch error reasons that are caused by user
+# input, rather than by a server-side bug. Logged below ERROR so they are not
+# reported to sentry.
+# Note that the same bad query surfaces different reasons depending on cluster
+# topology. On a single node cluster the shard failure stays in process and ES
+# reports its own QueryShardException ("Failed to parse query [...]"). On a
+# multi node cluster the shard is remote so the raw lucene exception surfaces
+# ("parse_exception: ...", "token_mgr_error: ...").
 _ES_CLIENT_ERROR_REASONS = (
     "no mapping found for",  # e.g. "No mapping found for [score] in order to sort on"
     "fielddata is disabled",  # e.g. sorting/aggregating on an analyzed text field
-    "failed to parse query",  # e.g. "Failed to parse query [entrezgene:-]"
+    "failed to parse query",  # e.g. "Failed to parse query [entrezgene:-]" (single node)
+    "parse_exception",  # e.g. 'parse_exception: Encountered " "-" "- ""' (multi node)
+    "token_mgr_error",  # e.g. "token_mgr_error: Lexical error at line 1" (multi node)
 )
 
 

--- a/biothings/web/settings/default.py
+++ b/biothings/web/settings/default.py
@@ -143,7 +143,7 @@ QUERY_KWARGS = {
         "scroll_id": {"type": str},
     },
     "POST": {
-        "q": {"type": list, "required": True},
+        "q": {"type": list, "required": True, "max": 5000},
         "scopes": {"type": list, "default": ["_id"], "max": 1000},
         "with_total": {"type": bool},
         "analyzer": {"type": str},  # any of built-in analyzer (overrides default index-time analyzer)

--- a/tests/web/options/test_batch_limits.py
+++ b/tests/web/options/test_batch_limits.py
@@ -1,0 +1,87 @@
+"""
+Tests the batch input size caps shipped in biothings.web.settings.default.
+
+Both batch endpoints bound how many items a single POST may carry, so that one
+request cannot fan out into an unbounded amount of Elasticsearch work:
+
+    POST /query       q    -> 5000 terms, each becoming a clause in an msearch
+    POST /<biothing>  ids  -> 1000 ids
+
+"""
+
+import pytest
+
+from biothings.web.options import OptionError, OptionSet
+from biothings.web.settings.default import ANNOTATION_KWARGS, QUERY_KWARGS
+
+QUERY_POST_MAX = 5000
+ANNOTATION_POST_MAX = 1000
+
+
+def _terms(count):
+    return [str(i) for i in range(count)]
+
+
+@pytest.mark.parametrize(
+    "kwargs, method, keyword, maximum",
+    [
+        (QUERY_KWARGS, "POST", "q", QUERY_POST_MAX),
+        (ANNOTATION_KWARGS, "POST", "id", ANNOTATION_POST_MAX),
+    ],
+    ids=["query_q", "annotation_id"],
+)
+def test_batch_cap_declared_on_a_list_parameter(kwargs, method, keyword, maximum):
+    # "max" is a no-op on non-list types, so the declared type matters
+    # as much as the number itself.
+    defdict = kwargs[method][keyword]
+    assert defdict["type"] is list
+    assert defdict["max"] == maximum
+
+
+@pytest.mark.parametrize(
+    "kwargs, method, keyword, maximum",
+    [
+        (QUERY_KWARGS, "POST", "q", QUERY_POST_MAX),
+        (ANNOTATION_KWARGS, "POST", "id", ANNOTATION_POST_MAX),
+    ],
+    ids=["query_q", "annotation_id"],
+)
+def test_batch_cap_enforced_at_the_boundary(kwargs, method, keyword, maximum):
+    optionset = OptionSet(kwargs)
+
+    # at the limit: accepted, and every item is preserved
+    args = optionset.parse(method, (None, None, {keyword: _terms(maximum)}))
+    assert len(args[keyword]) == maximum
+
+    # one over: rejected, and the error carries what the client needs to
+    # correct the request (this is what the handler turns into a 400 body).
+    with pytest.raises(OptionError) as err:
+        optionset.parse(method, (None, None, {keyword: _terms(maximum + 1)}))
+    assert err.value.info["keyword"] == keyword
+    assert err.value.info["max"] == maximum
+    assert err.value.info["size"] == maximum + 1
+
+
+def test_query_post_cap_applies_to_comma_separated_input():
+    # clients most often send q as a single comma-separated string rather than
+    # a JSON list; the cap has to survive that conversion too.
+    optionset = OptionSet(QUERY_KWARGS)
+
+    ok = ",".join(_terms(QUERY_POST_MAX))
+    assert len(optionset.parse("POST", (None, None, {"q": ok}))["q"]) == QUERY_POST_MAX
+
+    too_many = ",".join(_terms(QUERY_POST_MAX + 1))
+    with pytest.raises(OptionError) as err:
+        optionset.parse("POST", (None, None, {"q": too_many}))
+    assert err.value.info["size"] == QUERY_POST_MAX + 1
+
+
+def test_query_get_is_not_capped():
+    # GET q is a single query string, not a batch: it builds one Search rather
+    # than an msearch, so it is deliberately left uncapped here and bounded by
+    # the HTTP layer instead.
+    assert "max" not in QUERY_KWARGS["GET"]["q"]
+
+    optionset = OptionSet(QUERY_KWARGS)
+    long_q = "x" * (QUERY_POST_MAX * 2)
+    assert optionset.parse("GET", (None, {"q": long_q}))["q"] == long_q

--- a/tests/web/query/test_builder.py
+++ b/tests/web/query/test_builder.py
@@ -102,3 +102,29 @@ def test_elasticsearch_querybuilder_sort():
     query = builder.build("term", sort=["_score", "-taxid"]).to_dict()
     assert query["sort"] == ["_score", {"taxid": {"order": "desc"}}]
 
+    # sorting on '_id' is rejected up front: ES disallows fielddata on _id, so
+    # this would otherwise surface as an opaque shard error. Reject '_id',
+    # '-_id', '_id:desc', and '_id' anywhere in the list.
+    for sort in (["_id"], ["-_id"], ["_id:desc"], ["taxid", "-_id"]):
+        with pytest.raises(ValueError) as exc_info:
+            builder.build("term", sort=sort)
+        assert "_id" in str(exc_info.value)
+        assert "not available for sorting or aggregation" in str(exc_info.value)
+
+
+def test_elasticsearch_querybuilder_aggs_reject_id():
+    # aggregating on '_id' requires fielddata, which ES disallows on _id.
+    # Reject it up front (both top-level and nested aggregations).
+    builder = ESQueryBuilder()
+    with pytest.raises(ValueError) as exc_info:
+        builder.build("term", aggs=["_id"])
+    assert "not available for sorting or aggregation" in str(exc_info.value)
+
+    nested_builder = ESQueryBuilder(allow_nested_query=True)
+    with pytest.raises(ValueError) as exc_info:
+        nested_builder.build("term", aggs=["taxid(_id)"])
+    assert "not available for sorting or aggregation" in str(exc_info.value)
+
+    # a normal aggregation is unaffected
+    assert "aggs" in builder.build("term", aggs=["taxid"]).to_dict()
+

--- a/tests/web/query/test_formatter.py
+++ b/tests/web/query/test_formatter.py
@@ -44,6 +44,8 @@ def test_es_mapping_errors_logged_below_error(caplog):
         "No mapping found for [score] in order to sort on",
         "Fielddata is disabled on [name] in [my_index]. Text fields are not optimised for sorting...",
         "Failed to parse query [entrezgene:-]",
+        'parse_exception: Encountered " "-" "- "" at line 1, column 11.',
+        "token_mgr_error: Lexical error at line 1, column 21.  Encountered: <EOF>",
     ):
         caplog.clear()
         with caplog.at_level(logging.DEBUG), pytest.raises(ValueError) as exc_info:

--- a/tests/web/query/test_formatter.py
+++ b/tests/web/query/test_formatter.py
@@ -43,6 +43,7 @@ def test_es_mapping_errors_logged_below_error(caplog):
     for reason in (
         "No mapping found for [score] in order to sort on",
         "Fielddata is disabled on [name] in [my_index]. Text fields are not optimised for sorting...",
+        "Failed to parse query [entrezgene:-]",
     ):
         caplog.clear()
         with caplog.at_level(logging.DEBUG), pytest.raises(ValueError) as exc_info:


### PR DESCRIPTION
What's Changed
* Rejected `_id` as a sort or aggregation field with an actionable error message instead of an Elasticsearch fielddata failure by [@jal347](https://github.com/jal347) in [1747825](https://github.com/biothings/biothings.api/commit/17478250478b8e45458b56ca0ca8f8fa174ced97)
* Reduced Sentry noise for Elasticsearch query-parse failures caused by malformed user queries, covering both single-node and multi-node cluster error shapes, by [@jal347](https://github.com/jal347) in [#466](https://github.com/biothings/biothings.api/pull/466) and [9d71063](https://github.com/biothings/biothings.api/commit/9d710634c71d9a8580901fc46f138a10e5903775)
* Limited POST query batches to a maximum of 5000 query terms by [@jal347](https://github.com/jal347) in [e733d28](https://github.com/biothings/biothings.api/commit/e733d28987b7ca5f67347573c2b584f4cd146537)
* Lowered query-object parser logging from INFO to DEBUG by [@jal347](https://github.com/jal347) in [9d71063](https://github.com/biothings/biothings.api/commit/9d710634c71d9a8580901fc46f138a10e5903775)
* Added tests covering POST query batch limits by [@jal347](https://github.com/jal347) in [c5e00b8](https://github.com/biothings/biothings.api/commit/c5e00b88daaedca4f65ce6c5220b5a918887088f)

Full Changelog: [v1.1.3...v1.1.4](https://github.com/biothings/biothings.api/compare/v1.1.3...v1.1.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
